### PR TITLE
feat: Phase 3 — OpenClaw Gateway WebSocket 連携

### DIFF
--- a/apps/bridge/package.json
+++ b/apps/bridge/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "pretest": "pnpm -C ../.. --filter @avatar-agent/utils --filter @avatar-agent/schema build",
-    "test": "tsx --test src/brain.test.ts"
+    "test": "tsx --test src/brain.test.ts src/openclaw.test.ts"
   },
   "dependencies": {
     "@avatar-agent/schema": "workspace:*",

--- a/apps/bridge/src/openclaw.test.ts
+++ b/apps/bridge/src/openclaw.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for openclaw.ts
+ */
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { isAllowed, summarizeLog } from "./openclaw.js";
+
+// ── isAllowed() ──────────────────────────────────────────────────────────────
+
+describe("isAllowed()", () => {
+  // Allow cases
+  test("allows a normal browser search goal", () => {
+    assert.equal(isAllowed("ブラウザで天気を検索してください"), true);
+  });
+
+  test("allows opening an app", () => {
+    assert.equal(isAllowed("Spotify を起動してください"), true);
+  });
+
+  test("allows clipboard read request", () => {
+    assert.equal(isAllowed("クリップボードの内容を読み取ってください"), true);
+  });
+
+  // Deny cases
+  test("blocks rm command", () => {
+    assert.equal(isAllowed("rm -rf /tmp/test"), false);
+  });
+
+  test("blocks sudo usage", () => {
+    assert.equal(isAllowed("sudo apt-get install curl"), false);
+  });
+
+  test("blocks credential keyword", () => {
+    assert.equal(isAllowed("fetch my credential from keychain"), false);
+  });
+});
+
+// ── summarizeLog() ───────────────────────────────────────────────────────────
+
+describe("summarizeLog()", () => {
+  test("returns short log unchanged (within 500 chars)", () => {
+    // No error/success/result keywords → all lines returned as-is
+    const log = "step 1 done\nstep 2 done\nstep 3 done";
+    const result = summarizeLog(log);
+    assert.equal(result, log);
+  });
+
+  test("truncates long log to ≤ 500 chars", () => {
+    const longLine = "x".repeat(100);
+    const log = Array.from({ length: 20 }, (_, i) => `line ${i}: ${longLine}`).join(
+      "\n",
+    );
+    const result = summarizeLog(log);
+    assert.ok(result.length <= 500, `expected ≤500 chars, got ${result.length}`);
+  });
+
+  test("prioritizes error lines over other lines", () => {
+    const log = [
+      "step 1: starting task",
+      "step 2: processing data",
+      "ERROR: connection refused",
+      "step 3: retrying",
+    ].join("\n");
+    const result = summarizeLog(log);
+    assert.ok(
+      result.includes("ERROR"),
+      "expected error line to appear in summary",
+    );
+    assert.ok(
+      !result.includes("step 1"),
+      "expected non-error lines to be excluded when errors exist",
+    );
+  });
+});


### PR DESCRIPTION
Closes #2

## Summary
- `gatewayDelegate()` を実装: WebSocket で OpenClaw Gateway に接続し、`hello-ok` ハンドシェイク → `chat.send` → `chat.message` ログ蓄積 → `res` 受信 → `summarizeLog()` で要約して返す
- タイムアウト 70 秒で reject
- `isAllowed()` を deny-list (`DENY_PATTERNS`) ベースに変更 — keyword allowlist を廃止しシンプル化
- `openclaw.test.ts` 新規作成 (isAllowed 3 allow + 3 deny, summarizeLog 3件)
- `package.json` test スクリプトに `openclaw.test.ts` を追加

## Test plan
- [x] `pnpm --filter bridge test` → 29 tests pass
- [x] `pnpm --filter bridge typecheck` → 0 errors
- [x] `OPENCLAW_GATEWAY_URL` 未設定時 → stub 結果が返ること（ログ確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)