### PR TITLE
feat: Phase 4 — Hardening（セキュリティ・タイムアウト・エラーリカバリ）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # ─── Ollama ───────────────────────────────────────────────────────────────────
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=qwen3:8b
+OLLAMA_TIMEOUT_MS=60000
+OLLAMA_MAX_PREDICT=512
 
 # ─── Bridge HTTP server ────────────────────────────────────────────────────────
 BRIDGE_PORT=3000

--- a/apps/bridge/package.json
+++ b/apps/bridge/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
     "pretest": "pnpm -C ../.. --filter @avatar-agent/utils --filter @avatar-agent/schema build",
-    "test": "tsx --test src/brain.test.ts src/openclaw.test.ts"
+    "test": "tsx --test src/brain.test.ts src/openclaw.test.ts src/memory.test.ts"
   },
   "dependencies": {
     "@avatar-agent/schema": "workspace:*",

--- a/apps/bridge/src/brain.ts
+++ b/apps/bridge/src/brain.ts
@@ -125,6 +125,9 @@ export async function ask(
       trimHistory();
       return renderEvent;
     } catch (err) {
+      if (err instanceof TypeError && (err as TypeError).message.includes("fetch")) {
+        broadcast({ type: "status", state: "error", message: "Ollama に接続できません" });
+      }
       log.warn(`Attempt ${attempt + 1} error`, err);
     }
   }
@@ -169,10 +172,10 @@ async function callOllama(system: string, messages: ChatMessage[]): Promise<stri
       format: "json",
       options: {
         temperature: 0.7,
-        num_predict: 512,
+        num_predict: config.ollama.maxPredictTokens,
       },
     }),
-    signal: AbortSignal.timeout(60_000),
+    signal: AbortSignal.timeout(config.ollama.timeoutMs),
   });
 
   if (!res.ok) {

--- a/apps/bridge/src/memory.test.ts
+++ b/apps/bridge/src/memory.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for memory.ts — applyMemoryUpdate()
+ */
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+// We need to override config.memory.dir before importing memory.ts.
+// Use process.env so config.ts picks it up at import time.
+
+let tmpDir: string;
+
+// applyMemoryUpdate is imported after tmpDir is set via env.
+let applyMemoryUpdate: (diff: string) => Promise<void>;
+
+before(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "avatar-memory-test-"));
+  process.env["MEMORY_DIR"] = tmpDir;
+
+  // Dynamic import after env is set
+  const mod = await import("./memory.js");
+  applyMemoryUpdate = mod.applyMemoryUpdate;
+});
+
+after(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("applyMemoryUpdate()", () => {
+  test("NOOP → ファイル変更なし", async () => {
+    await applyMemoryUpdate("NOOP");
+    // user_profile.md should not exist
+    try {
+      await readFile(join(tmpDir, "user_profile.md"), "utf-8");
+      assert.fail("user_profile.md should not exist after NOOP");
+    } catch (err: unknown) {
+      assert.equal((err as NodeJS.ErrnoException).code, "ENOENT");
+    }
+  });
+
+  test("通常テキスト → タイムスタンプ付きで追記される", async () => {
+    const diff = "- ユーザーの名前は Bob です";
+    await applyMemoryUpdate(diff);
+
+    const content = await readFile(join(tmpDir, "user_profile.md"), "utf-8");
+    assert.ok(content.includes(diff), "diff text should be in user_profile.md");
+    // No timestamp on first write (content starts with the diff itself)
+  });
+
+  test("2回目の追記 → 既存内容に追加される", async () => {
+    const second = "- 好きな食べ物はピザ";
+    await applyMemoryUpdate(second);
+
+    const content = await readFile(join(tmpDir, "user_profile.md"), "utf-8");
+    assert.ok(content.includes("Bob"), "first update should still be present");
+    assert.ok(content.includes(second), "second update should be appended");
+    assert.ok(content.includes("<!-- updated"), "timestamp comment should be present");
+  });
+});

--- a/packages/utils/src/config.ts
+++ b/packages/utils/src/config.ts
@@ -19,8 +19,10 @@ function envInt(key: string, fallback: number): number {
 
 export const config = {
   ollama: {
-    baseUrl: env("OLLAMA_BASE_URL", "http://localhost:11434"),
-    model:   env("OLLAMA_MODEL", "qwen3:8b"),
+    baseUrl:          env("OLLAMA_BASE_URL", "http://localhost:11434"),
+    model:            env("OLLAMA_MODEL", "qwen3:8b"),
+    timeoutMs:        envInt("OLLAMA_TIMEOUT_MS", 60_000),
+    maxPredictTokens: envInt("OLLAMA_MAX_PREDICT", 512),
   },
   bridge: {
     port: envInt("BRIDGE_PORT", 3000),


### PR DESCRIPTION
Closes #3

## Summary
- **config.ts**: `OLLAMA_TIMEOUT_MS`（デフォルト 60s）・`OLLAMA_MAX_PREDICT`（デフォルト 512）を env から読み込み
- **.env.example**: Ollama セクションに2変数を追記
- **server.ts**: `bodyLimit: 8192`、SSE 接続数を `MAX_SSE_CLIENTS=3` で制限（超過時 429）、非 localhost バインド時に `log.warn` を出力
- **brain.ts**: タイムアウトと `num_predict` を config 経由に変更、Ollama fetch エラー（TypeError）を検出してユーザーにエラー状態を通知
- **renderer.ts**: SSE 再接続を指数バックオフ（3s → 6s → 12s → max 30s）に変更、成功メッセージ受信時にリセット
- **memory.test.ts**: `applyMemoryUpdate()` を tmp dir でテスト（NOOP・初回書き込み・追記の 3 件）
- **package.json**: test スクリプトに `memory.test.ts` を追加

## Test plan
- [x] `pnpm --filter bridge test` → 32 tests pass
- [x] `pnpm --filter bridge typecheck` → 0 errors
- [x] `pnpm --filter ui typecheck` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)