### PR TITLE
fix: Qwen3.5 の思考モードを無効化してタイムアウトを解消

### DIFF
--- a/apps/bridge/src/brain.ts
+++ b/apps/bridge/src/brain.ts
@@ -242,6 +242,7 @@ async function callOllama(system: string, messages: ChatMessage[]): Promise<stri
         ...messages,
       ],
       format: "json",
+      think: false,
       options: {
         temperature: 0.75,
         num_predict: config.ollama.maxPredictTokens,


### PR DESCRIPTION
## Summary

- Ollama API リクエストに `think: false` を追加し、Qwen3.5 の思考モードを無効化
- 思考モードが有効だと 1 tok/~5s かかり 60 秒タイムアウト内に完了しなかった

## Test plan

- [ ] `qwen3.5:2b` に対して `おはよう` と送信し、5秒以内に返答が来ることを確認

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)