### PR TITLE
feat: remote-GPU バックエンド対応（SSH ポートフォワード経由 /generate API）

### DIFF
--- a/apps/bridge/src/brain.ts
+++ b/apps/bridge/src/brain.ts
@@ -35,6 +35,9 @@ const MAX_HISTORY_MESSAGES = 10;
 let currentModel = config.ollama.model;
 
 export function setModel(model: string): void {
+  if (config.brainBackend === "remote-gpu") {
+    throw new Error("Model switching is not supported for remote-gpu backend");
+  }
   if (!config.ollama.availableModels.includes(model)) {
     throw new Error(`Unknown model: ${model}. Available: ${config.ollama.availableModels.join(", ")}`);
   }
@@ -229,6 +232,10 @@ async function streamOllamaResponse(
 
   const TEXT_MARKER_RE = /"text"\s*:\s*"/;
 
+  if (config.brainBackend === "remote-gpu") {
+    return callRemoteGpuResponse(system, messages, broadcast);
+  }
+
   const gen = callOllamaStream(system, messages);
   let next = await gen.next();
 
@@ -316,6 +323,72 @@ async function streamOllamaResponse(
 
   log.debug("Stream complete", { chars: accumulatedText.length, emotion, motion, tokensPerSec: metrics.tokensPerSec, ttftMs });
   return { text: accumulatedText, emotion, motion, rawBuffer: buffer, tokensPerSec: metrics.tokensPerSec, ttftMs };
+}
+
+// ── Remote GPU (non-streaming) REST call ──────────────────────────────────────
+async function callRemoteGpuResponse(
+  system: string,
+  messages: ChatMessage[],
+  broadcast: (event: UIEvent) => void,
+): Promise<{ text: string; emotion: Emotion; motion: Motion; rawBuffer: string; tokensPerSec?: number; ttftMs?: number }> {
+  const { baseUrl, maxNewTokens, temperature, timeoutMs } = config.remoteGpu;
+
+  // Build prompt: system + conversation history as plain text
+  const historyText = messages
+    .map((m) => (m.role === "user" ? `ユーザー: ${m.content}` : `アシスタント: ${m.content}`))
+    .join("\n");
+  const prompt = `${system}\n\n${historyText}\nアシスタント:`;
+
+  const startMs = Date.now();
+
+  const res = await fetch(`${baseUrl}/generate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      prompt,
+      max_new_tokens: maxNewTokens,
+      temperature,
+      do_sample: temperature > 0,
+    }),
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`remote-gpu ${res.status}: ${truncate(body, 200)}`);
+  }
+
+  const data = await res.json() as { generated_text: string; elapsed_sec?: number };
+  const ttftMs = Date.now() - startMs;
+  const rawBuffer = data.generated_text.trim();
+  const tokensPerSec = data.elapsed_sec ? maxNewTokens / data.elapsed_sec : undefined;
+
+  // Parse JSON from the generated text
+  const parsed = extractJSON(repairJSON(rawBuffer));
+
+  let emotion: Emotion = "neutral";
+  let motion: Motion = "none";
+  let accumulatedText = "";
+
+  if (parsed) {
+    emotion = isValidEmotion(parsed["emotion"]) ? parsed["emotion"] as Emotion : "neutral";
+    motion = isValidMotion(parsed["motion"]) ? parsed["motion"] as Motion : "none";
+    accumulatedText = typeof parsed["text"] === "string" ? parsed["text"].trim() : "";
+  }
+
+  // Emit events character-by-character to keep UI experience consistent
+  broadcast({ type: "render_start", emotion, motion });
+  for (const char of accumulatedText) {
+    broadcast({ type: "render_token", token: char });
+  }
+  broadcast({ type: "render_end" });
+
+  if (!accumulatedText) {
+    throw new Error("No text extracted from remote-gpu response");
+  }
+
+  log.debug("remote-gpu complete", { chars: accumulatedText.length, emotion, motion, tokensPerSec, ttftMs });
+  return { text: accumulatedText, emotion, motion, rawBuffer, tokensPerSec, ttftMs };
 }
 
 // ── Ollama streaming REST call ────────────────────────────────────────────────

--- a/packages/utils/src/config.ts
+++ b/packages/utils/src/config.ts
@@ -18,12 +18,19 @@ function envInt(key: string, fallback: number): number {
 }
 
 export const config = {
+  brainBackend: env("BRAIN_BACKEND", "ollama") as "ollama" | "remote-gpu",
   ollama: {
     baseUrl:          env("OLLAMA_BASE_URL", "http://localhost:11434"),
     model:            env("OLLAMA_MODEL", "qwen3.5:2b"),
     availableModels:  env("OLLAMA_AVAILABLE_MODELS", "qwen3.5:2b").split(",") as string[],
     timeoutMs:        envInt("OLLAMA_TIMEOUT_MS", 60_000),
     maxPredictTokens: envInt("OLLAMA_MAX_PREDICT", 512),
+  },
+  remoteGpu: {
+    baseUrl:       env("REMOTE_GPU_BASE_URL", "http://127.0.0.1:10003"),
+    maxNewTokens:  envInt("REMOTE_GPU_MAX_NEW_TOKENS", 512),
+    temperature:   parseFloat(env("REMOTE_GPU_TEMPERATURE", "0.75")),
+    timeoutMs:     envInt("REMOTE_GPU_TIMEOUT_MS", 120_000),
   },
   bridge: {
     port: envInt("BRIDGE_PORT", 3000),


### PR DESCRIPTION
## Summary

- `BRAIN_BACKEND=remote-gpu` 環境変数でバックエンドを Ollama から遠隔 GPU サーバーに切り替えられるようにした
- SSH ポートフォワード（`ssh -L 10003:localhost:10003 remote-host`）時に `http://127.0.0.1:10003/generate` を叩く
- 非ストリーミング API だが、受け取った `generated_text` をキャラクター単位で `render_token` emit することで UI 体験を維持

## 変更ファイル

**`packages/utils/src/config.ts`**
- `brainBackend`: `BRAIN_BACKEND` 環境変数（`"ollama"` / `"remote-gpu"`、デフォルト `"ollama"`）
- `remoteGpu` セクション追加: `REMOTE_GPU_BASE_URL`, `REMOTE_GPU_MAX_NEW_TOKENS`, `REMOTE_GPU_TEMPERATURE`, `REMOTE_GPU_TIMEOUT_MS`

**`apps/bridge/src/brain.ts`**
- `callRemoteGpuResponse()` 追加: POST `/generate` → JSON パース → render イベント emit
- `streamOllamaResponse()` 冒頭で `brainBackend` を見てルーティング
- `setModel()` は `remote-gpu` 時に例外を返す

## 使い方

```bash
# SSH ポートフォワードを張った状態で
BRAIN_BACKEND=remote-gpu REMOTE_GPU_BASE_URL=http://127.0.0.1:10003 pnpm dev
```

## Test plan

- [ ] `BRAIN_BACKEND` 未設定 → 従来の Ollama 動作に変化なし（全 32 テスト通過確認済み）
- [ ] `BRAIN_BACKEND=remote-gpu` + GPU サーバー起動時 → アバターが応答する

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)