### PR TITLE
feat: remote-GPU 時のモデル選択 UI をラベル表示に変更 + README 追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,62 @@ ollama pull qwen3.5:2b
 ### 起動
 
 ```bash
-# bridge + UI を同時起動
+# bridge + UI を同時起動（ローカル Ollama 使用）
 pnpm dev
+```
+
+### リモート GPU バックエンドで起動する
+
+GPU サーバ上で `/generate` API を立てておき、SSH ポートフォワードでローカルに転送する方法です。
+
+#### 1. SSH ポートフォワードを張る
+
+別ターミナルで以下を実行し、GPU サーバのポートをローカル `10003` に転送します。
+
+```bash
+# ssh -L <ローカルポート>:<サーバ内ホスト>:<サーバポート> <SSHホスト>
+ssh -L 10003:localhost:10003 your-gpu-server
+```
+
+> `your-gpu-server` は `~/.ssh/config` のホスト名や `user@hostname` で指定してください。
+> サーバ側の `/generate` API がポート `10003` で起動している想定です。
+
+#### 2. アプリを起動する
+
+```bash
+BRAIN_BACKEND=remote-gpu REMOTE_GPU_BASE_URL=http://127.0.0.1:10003 pnpm dev
+```
+
+| 環境変数 | 説明 | デフォルト |
+|---------|------|-----------|
+| `BRAIN_BACKEND` | `ollama`（ローカル）または `remote-gpu` | `ollama` |
+| `REMOTE_GPU_BASE_URL` | `/generate` API のベース URL | `http://127.0.0.1:10003` |
+| `REMOTE_GPU_MAX_NEW_TOKENS` | 最大生成トークン数 | `512` |
+| `REMOTE_GPU_TEMPERATURE` | サンプリング温度 | `0.75` |
+| `REMOTE_GPU_TIMEOUT_MS` | タイムアウト（ms） | `120000` |
+
+#### `/generate` API の仕様
+
+GPU サーバ側は以下のリクエスト／レスポンスに対応している必要があります。
+
+**リクエスト（POST `/generate`）**
+
+```json
+{
+  "prompt": "<システムプロンプト + 会話履歴>",
+  "max_new_tokens": 512,
+  "temperature": 0.75,
+  "do_sample": true
+}
+```
+
+**レスポンス**
+
+```json
+{
+  "generated_text": "{\"emotion\":\"happy\",\"motion\":\"wave\",\"text\":\"...\",\"memory_update\":\"NOOP\",\"task\":null}",
+  "elapsed_sec": 1.23
+}
 ```
 
 ### 送信キー

--- a/apps/bridge/src/server.ts
+++ b/apps/bridge/src/server.ts
@@ -57,7 +57,7 @@ export async function startServer(session?: SessionLogger) {
 
   // ── Models ──────────────────────────────────────────────────────────────────
   app.get("/models", async (_req, reply) => {
-    return reply.send({ current: getCurrentModel(), available: config.ollama.availableModels });
+    return reply.send({ current: getCurrentModel(), available: config.ollama.availableModels, backend: config.brainBackend });
   });
 
   app.post<{ Body: { model: string } }>("/model", {

--- a/apps/ui/src/renderer/index.html
+++ b/apps/ui/src/renderer/index.html
@@ -66,6 +66,12 @@
       padding: 2px 6px;
       cursor: pointer;
     }
+    #model-label {
+      display: none;
+      font-size: 11px;
+      color: rgba(255,255,255,0.75);
+      padding: 2px 6px;
+    }
 
     /* ── Status bar ────────────────────────────────────────── */
     #status-bar {
@@ -116,6 +122,7 @@
     <canvas id="avatar-canvas" width="320" height="320"></canvas>
     <div id="model-area">
       <select id="model-select"></select>
+      <span id="model-label"></span>
     </div>
     <div id="status-bar"></div>
     <div id="speech-bubble">...</div>

--- a/apps/ui/src/renderer/renderer.ts
+++ b/apps/ui/src/renderer/renderer.ts
@@ -22,6 +22,7 @@ const statusBar   = document.getElementById("status-bar") as HTMLDivElement;
 const userInput   = document.getElementById("user-input") as HTMLInputElement;
 const sendBtn     = document.getElementById("send-btn") as HTMLButtonElement;
 const modelSelect = document.getElementById("model-select") as HTMLSelectElement;
+const modelLabel  = document.getElementById("model-label") as HTMLSpanElement;
 
 // ── Components ────────────────────────────────────────────────────────────────
 const avatar = new AvatarRenderer(canvas, 8);
@@ -45,7 +46,13 @@ async function loadModels() {
   try {
     const res = await fetch(`${bridgeBase}/models`);
     if (!res.ok) return;
-    const data = await res.json() as { current: string; available: string[] };
+    const data = await res.json() as { current: string; available: string[]; backend: string };
+    if (data.backend === "remote-gpu") {
+      modelSelect.style.display = "none";
+      modelLabel.style.display = "inline";
+      modelLabel.textContent = "remote-gpu";
+      return;
+    }
     modelSelect.innerHTML = "";
     for (const m of data.available) {
       const opt = document.createElement("option");


### PR DESCRIPTION
## Summary

- `BRAIN_BACKEND=remote-gpu` で起動した場合、モデル選択セレクトを非表示にして「remote-gpu」ラベルを表示
- `/models` レスポンスに `backend` フィールドを追加（UI 側で判定に使用）
- README にリモート GPU バックエンドの詳細な起動手順を追記（SSH ポートフォワード・環境変数一覧・API 仕様）

## Test plan

- [ ] `pnpm dev`（通常起動）でモデル選択セレクトが従来通り表示されること
- [ ] `BRAIN_BACKEND=remote-gpu pnpm dev` で「remote-gpu」ラベルが表示され、セレクトが非表示になること
- [ ] `pnpm -r build` が通ること（確認済み）

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)