### PR TITLE
fix: remote-GPU 時の口パクを修正

### DIFF
--- a/apps/bridge/src/brain.ts
+++ b/apps/bridge/src/brain.ts
@@ -376,12 +376,9 @@ async function callRemoteGpuResponse(
     accumulatedText = typeof parsed["text"] === "string" ? parsed["text"].trim() : "";
   }
 
-  // Emit events character-by-character to keep UI experience consistent
-  broadcast({ type: "render_start", emotion, motion });
-  for (const char of accumulatedText) {
-    broadcast({ type: "render_token", token: char });
-  }
-  broadcast({ type: "render_end" });
+  // Use render event (not streaming events) so typewriter.play() handles
+  // character-by-character timing and lipsync on the renderer side.
+  broadcast({ type: "render", emotion, motion, text: accumulatedText });
 
   if (!accumulatedText) {
     throw new Error("No text extracted from remote-gpu response");


### PR DESCRIPTION
## Summary

- `callRemoteGpuResponse` が `render_start`/`render_token`/`render_end` をバースト送信していたため、レンダラー側の setInterval（120ms）が発火する前に `endStream()` が呼ばれ口パクが動作しなかった
- `render` イベント1つに変更し、`typewriter.play()` で文字単位遅延（45ms/char）とリップシンクをレンダラー側で処理させるよう修正

## Test plan

- [ ] remote-GPU バックエンドで起動してメッセージ送信
- [ ] アバターの口が話している間パクパクすることを確認

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)