### PR TITLE
feat: Interaction Logging + Memory 基盤 (Phase 9–13)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ BRIDGE_PORT=3000
 # Bind to localhost only (never 0.0.0.0 for security)
 BRIDGE_HOST=127.0.0.1
 
+# ─── Python agent service (FastAPI: logging / feedback / analytics) ────────────
+# `pnpm dev:agent` で起動。停止していても会話は動く（ログ・フィードバックは best-effort）
+AGENT_SERVICE_URL=http://127.0.0.1:8000
+
 # ─── OpenClaw Gateway (Phase 3) ───────────────────────────────────────────────
 # Uncomment and fill when setting up OpenClaw integration
 # OPENCLAW_GATEWAY_URL=ws://localhost:7070

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 *.egg-info/
+
+# Local interaction-log / memory databases (Phase 9+)
+*.sqlite
+*.sqlite-journal
+*.sqlite-wal

--- a/apps/bridge/src/brain.ts
+++ b/apps/bridge/src/brain.ts
@@ -31,6 +31,15 @@ let stubIndex = 0;
 const MAX_RETRIES = 2;
 const MAX_HISTORY_MESSAGES = 10;
 
+// Result of a completed turn, surfaced so the bridge can log it to the agent service.
+export interface TurnResult {
+  user: string;
+  assistant: string;
+  emotion: Emotion;
+  motion: Motion;
+  latencyMs: number;
+}
+
 // ── Runtime model state ───────────────────────────────────────────────────────
 let currentModel = config.ollama.model;
 
@@ -113,7 +122,7 @@ export async function ask(
   userMessage: string,
   broadcast: (event: UIEvent) => void,
   session?: SessionLogger,
-): Promise<void> {
+): Promise<TurnResult | null> {
   if (STUB_MODE) {
     log.info(`[STUB] responding to: "${userMessage}"`);
     const response = STUB_RESPONSES[stubIndex % STUB_RESPONSES.length]!;
@@ -123,7 +132,7 @@ export async function ask(
       broadcast({ type: "render_token", token: char });
     }
     broadcast({ type: "render_end" });
-    return;
+    return null;
   }
 
   const memory = await readMemory();
@@ -176,7 +185,7 @@ export async function ask(
         ttft_ms: ttftMs,
       }).catch((e) => log.warn("session log failed", e));
 
-      return;
+      return { user: userMessage, assistant: text, emotion, motion, latencyMs: Date.now() - startMs };
     } catch (err) {
       if (err instanceof TypeError && (err as TypeError).message.includes("fetch")) {
         broadcast({ type: "status", state: "error", message: "Ollama に接続できません" });
@@ -200,6 +209,8 @@ export async function ask(
     motion: "none",
     latency_ms: Date.now() - startMs,
   }).catch((e) => log.warn("session log failed", e));
+
+  return { user: userMessage, assistant: fallbackText, emotion: "confused", motion: "none", latencyMs: Date.now() - startMs };
 }
 
 /** Expose history for testing */

--- a/apps/bridge/src/server.ts
+++ b/apps/bridge/src/server.ts
@@ -11,11 +11,57 @@ import cors from "@fastify/cors";
 import type { UIEvent } from "@avatar-agent/schema";
 import { config, createLogger } from "@avatar-agent/utils";
 import { ask, setModel, getCurrentModel } from "./brain.js";
+import type { TurnResult } from "./brain.js";
 import type { SessionLogger } from "./session.js";
 
 const log = createLogger("server");
 
 const MAX_SSE_CLIENTS = 3;
+
+// ── Python agent service (best-effort: chat must keep working if it is down) ──
+const agentBase = config.agentService.baseUrl;
+let agentSessionId: string | null = null;
+
+async function ensureAgentSession(): Promise<string | null> {
+  if (agentSessionId) return agentSessionId;
+  try {
+    const res = await fetch(`${agentBase}/sessions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: getCurrentModel() }),
+    });
+    if (!res.ok) return null;
+    const data = await res.json() as { id: string };
+    agentSessionId = data.id;
+    return agentSessionId;
+  } catch {
+    return null; // agent service not running — skip logging
+  }
+}
+
+async function logTurnToAgent(result: TurnResult): Promise<string | null> {
+  const sid = await ensureAgentSession();
+  if (!sid) return null;
+  try {
+    const res = await fetch(`${agentBase}/sessions/${sid}/turns`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        user_input: result.user,
+        assistant_output: result.assistant,
+        model: getCurrentModel(),
+        emotion: result.emotion,
+        motion: result.motion,
+        latency_ms: result.latencyMs,
+      }),
+    });
+    if (!res.ok) return null;
+    const data = await res.json() as { id: string };
+    return data.id;
+  } catch {
+    return null;
+  }
+}
 
 // SSE subscriber registry
 type Subscriber = (event: UIEvent) => void;
@@ -130,9 +176,10 @@ export async function startServer(session?: SessionLogger) {
     broadcast({ type: "status", state: "running", message: "考え中..." });
 
     try {
-      await ask(message, broadcast, session);
+      const result = await ask(message, broadcast, session);
       broadcast({ type: "status", state: "idle", message: "Ready" });
-      return reply.send({ ok: true });
+      const turnId = result ? await logTurnToAgent(result) : null;
+      return reply.send({ ok: true, turnId });
     } catch (err) {
       log.error("Brain error", err);
       broadcast({
@@ -141,6 +188,35 @@ export async function startServer(session?: SessionLogger) {
         message: "エラーが発生しました。もう一度お試しください。",
       });
       return reply.status(500).send({ ok: false, error: "Brain error" });
+    }
+  });
+
+  // ── Feedback (proxy to agent service) ─────────────────────────────────────────
+  app.post<{ Body: { turnId: string; rating?: number; label?: string; comment?: string } }>("/feedback", {
+    schema: {
+      body: {
+        type: "object",
+        required: ["turnId"],
+        properties: {
+          turnId: { type: "string", minLength: 1 },
+          rating: { type: "integer", minimum: 1, maximum: 5 },
+          label: { type: "string", maxLength: 64 },
+          comment: { type: "string", maxLength: 2000 },
+        },
+      },
+    },
+  }, async (req, reply) => {
+    const { turnId, rating, label, comment } = req.body;
+    try {
+      const res = await fetch(`${agentBase}/turns/${turnId}/feedback`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ rating, label, comment }),
+      });
+      if (!res.ok) return reply.status(502).send({ ok: false, error: "agent service error" });
+      return reply.send({ ok: true });
+    } catch {
+      return reply.status(503).send({ ok: false, error: "agent service unavailable" });
     }
   });
 

--- a/apps/ui/src/main.ts
+++ b/apps/ui/src/main.ts
@@ -47,10 +47,12 @@ ipcMain.handle("chat:send", async (_event, message: string) => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ message }),
     });
-    return res.ok;
+    if (!res.ok) return { ok: false, turnId: null };
+    const data = await res.json() as { ok: boolean; turnId?: string | null };
+    return { ok: data.ok, turnId: data.turnId ?? null };
   } catch (err) {
     log.error("Failed to send chat message", err);
-    return false;
+    return { ok: false, turnId: null };
   }
 });
 

--- a/apps/ui/src/preload.ts
+++ b/apps/ui/src/preload.ts
@@ -6,7 +6,7 @@ import { contextBridge, ipcRenderer } from "electron";
 
 contextBridge.exposeInMainWorld("avatarBridge", {
   sendMessage: (message: string) =>
-    ipcRenderer.invoke("chat:send", message) as Promise<boolean>,
+    ipcRenderer.invoke("chat:send", message) as Promise<{ ok: boolean; turnId: string | null }>,
   getSseUrl: () =>
     ipcRenderer.invoke("sse:url") as Promise<string>,
 });

--- a/apps/ui/src/renderer/index.html
+++ b/apps/ui/src/renderer/index.html
@@ -115,6 +115,26 @@
     }
     #send-btn:hover { background: #5a8fe8; }
     #send-btn:disabled { background: #aaa; cursor: not-allowed; }
+
+    #feedback-bar {
+      display: flex;
+      gap: 6px;
+      justify-content: center;
+      min-height: 26px;
+      margin-top: 4px;
+    }
+    #feedback-bar button {
+      border: none;
+      border-radius: 14px;
+      padding: 3px 10px;
+      font-size: 13px;
+      cursor: pointer;
+      background: rgba(255,255,255,0.85);
+      transition: background 0.15s;
+    }
+    #feedback-bar button:hover { background: #fff; }
+    #feedback-bar button:disabled { opacity: 0.5; cursor: default; }
+    #feedback-bar .thanks { font-size: 12px; color: #5a8fe8; align-self: center; }
   </style>
 </head>
 <body>
@@ -126,6 +146,7 @@
     </div>
     <div id="status-bar"></div>
     <div id="speech-bubble">...</div>
+    <div id="feedback-bar"></div>
     <div id="input-area">
       <input id="user-input" type="text" placeholder="話しかけてみてください..." maxlength="400" />
       <button id="send-btn">送信</button>

--- a/apps/ui/src/renderer/renderer.ts
+++ b/apps/ui/src/renderer/renderer.ts
@@ -9,7 +9,7 @@ import { Typewriter } from "./typewriter.js";
 declare global {
   interface Window {
     avatarBridge: {
-      sendMessage: (msg: string) => Promise<boolean>;
+      sendMessage: (msg: string) => Promise<{ ok: boolean; turnId: string | null }>;
       getSseUrl: () => Promise<string>;
     };
   }
@@ -23,6 +23,7 @@ const userInput   = document.getElementById("user-input") as HTMLInputElement;
 const sendBtn     = document.getElementById("send-btn") as HTMLButtonElement;
 const modelSelect = document.getElementById("model-select") as HTMLSelectElement;
 const modelLabel  = document.getElementById("model-label") as HTMLSpanElement;
+const feedbackBar = document.getElementById("feedback-bar") as HTMLDivElement;
 
 // ── Components ────────────────────────────────────────────────────────────────
 const avatar = new AvatarRenderer(canvas, 8);
@@ -153,6 +154,64 @@ function setStatus(state: "running" | "idle" | "error", message: string) {
   statusBar.className = state === "error" ? "error" : "";
 }
 
+// ── Feedback (Phase 11) ─────────────────────────────────────────────────────
+function clearFeedback() {
+  feedbackBar.replaceChildren();
+}
+
+async function submitFeedback(turnId: string, rating: number, label: string, comment?: string) {
+  try {
+    await fetch(`${bridgeBase}/feedback`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ turnId, rating, label, comment }),
+    });
+    clearFeedback();
+    const thanks = document.createElement("span");
+    thanks.className = "thanks";
+    thanks.textContent = "フィードバックありがとう";
+    feedbackBar.appendChild(thanks);
+  } catch {
+    setStatus("error", "フィードバック送信に失敗しました");
+  }
+}
+
+function showCommentInput(turnId: string) {
+  clearFeedback();
+  const input = document.createElement("input");
+  input.type = "text";
+  input.placeholder = "フィードバックを書く...";
+  input.maxLength = 2000;
+  const send = document.createElement("button");
+  send.textContent = "送信";
+  send.addEventListener("click", () => {
+    const comment = input.value.trim();
+    if (comment) submitFeedback(turnId, 3, "comment", comment);
+  });
+  feedbackBar.append(input, send);
+  input.focus();
+}
+
+function showFeedbackButtons(turnId: string) {
+  clearFeedback();
+  const good = document.createElement("button");
+  good.textContent = "👍";
+  good.title = "良い";
+  good.addEventListener("click", () => submitFeedback(turnId, 5, "helpful"));
+
+  const bad = document.createElement("button");
+  bad.textContent = "👎";
+  bad.title = "微妙";
+  bad.addEventListener("click", () => submitFeedback(turnId, 2, "not_helpful"));
+
+  const note = document.createElement("button");
+  note.textContent = "📝";
+  note.title = "理由を書く";
+  note.addEventListener("click", () => showCommentInput(turnId));
+
+  feedbackBar.append(good, bad, note);
+}
+
 // ── Input handling ────────────────────────────────────────────────────────────
 async function sendMessage() {
   const msg = userInput.value.trim();
@@ -161,12 +220,16 @@ async function sendMessage() {
   sendBtn.disabled = true;
   userInput.value = "";
   bubble.textContent = "...";
+  clearFeedback();
 
-  const ok = await window.avatarBridge.sendMessage(msg);
-  if (!ok) {
+  const result = await window.avatarBridge.sendMessage(msg);
+  if (!result.ok) {
     setStatus("error", "送信に失敗しました");
     sendBtn.disabled = false;
+    return;
   }
+  // turnId is null when the agent service is down or in stub mode — skip feedback UI.
+  if (result.turnId) showFeedbackButtons(result.turnId);
 }
 
 sendBtn.addEventListener("click", sendMessage);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "Desktop companion with sprite avatar, Ollama LLM, and OpenClaw desktop automation",
   "scripts": {
     "dev": "concurrently --names \"bridge,ui\" --prefix-colors \"cyan,magenta\" --kill-others-on-fail \"pnpm --filter bridge dev\" \"pnpm --filter ui dev\"",
+    "dev:agent": "uv run --directory services/agent uvicorn agent.app:app --port 8000",
+    "dev:all": "concurrently --names \"agent,bridge,ui\" --prefix-colors \"green,cyan,magenta\" \"pnpm dev:agent\" \"pnpm --filter bridge dev\" \"pnpm --filter ui dev\"",
     "build": "pnpm -r build",
     "test": "pnpm -r test",
     "lint": "pnpm -r lint",

--- a/packages/utils/src/config.ts
+++ b/packages/utils/src/config.ts
@@ -33,6 +33,10 @@ export const config = {
     temperature:   parseFloat(env("REMOTE_GPU_TEMPERATURE", "0.75")),
     timeoutMs:     envInt("REMOTE_GPU_TIMEOUT_MS", 120_000),
   },
+  // Python agent service (FastAPI): interaction logging / feedback / analytics
+  agentService: {
+    baseUrl: env("AGENT_SERVICE_URL", "http://127.0.0.1:8000"),
+  },
   bridge: {
     port: envInt("BRIDGE_PORT", 3000),
     host: env("BRIDGE_HOST", "127.0.0.1"),

--- a/services/agent/src/agent/app.py
+++ b/services/agent/src/agent/app.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from agent.config import settings
 from agent.logger.interaction_logger import (
     AvatarEventLog,
+    ExplicitFeedbackLog,
     InteractionLogger,
     MemoryAccessLog,
     PromptLog,
@@ -54,6 +55,12 @@ class LogTurnRequest(BaseModel):
 
 class EndSessionRequest(BaseModel):
     summary: str | None = None
+
+
+class FeedbackRequest(BaseModel):
+    rating: int | None = None
+    label: str | None = None
+    comment: str | None = None
 
 
 @app.get("/health")
@@ -135,3 +142,21 @@ def get_memory_accesses(turn_id: str, logger: LoggerDep) -> list[MemoryAccessLog
 @app.get("/turns/{turn_id}/avatar-events")
 def get_avatar_events(turn_id: str, logger: LoggerDep) -> list[AvatarEventLog]:
     return logger.get_avatar_events(turn_id)
+
+
+# ── Phase 11: explicit feedback ────────────────────────────────────────────────
+
+
+@app.post("/turns/{turn_id}/feedback", status_code=status.HTTP_201_CREATED)
+def post_feedback(turn_id: str, req: FeedbackRequest, logger: LoggerDep) -> ExplicitFeedbackLog:
+    return logger.log_explicit_feedback(
+        turn_id,
+        rating=req.rating,
+        label=req.label,
+        comment=req.comment,
+    )
+
+
+@app.get("/turns/{turn_id}/feedback")
+def get_feedback(turn_id: str, logger: LoggerDep) -> list[ExplicitFeedbackLog]:
+    return logger.get_feedback(turn_id)

--- a/services/agent/src/agent/app.py
+++ b/services/agent/src/agent/app.py
@@ -10,7 +10,15 @@ from fastapi import Depends, FastAPI, HTTPException, status
 from pydantic import BaseModel
 
 from agent.config import settings
-from agent.logger.interaction_logger import InteractionLogger, Session, TurnLog
+from agent.logger.interaction_logger import (
+    AvatarEventLog,
+    InteractionLogger,
+    MemoryAccessLog,
+    PromptLog,
+    Session,
+    ToolCallLog,
+    TurnLog,
+)
 
 app = FastAPI(title="avatar-agent", version="0.1.0")
 
@@ -102,3 +110,28 @@ def end_session(session_id: str, req: EndSessionRequest, logger: LoggerDep) -> S
     if session is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="session not found")
     return session
+
+
+# ── Phase 10: read prompt / tool / memory-access / avatar logs for a turn ──────
+# Writes happen in-process via InteractionLogger while a turn is being answered;
+# these endpoints expose the records for inspection and the dashboard (Phase 16).
+
+
+@app.get("/turns/{turn_id}/prompts")
+def get_prompts(turn_id: str, logger: LoggerDep) -> list[PromptLog]:
+    return logger.get_prompts(turn_id)
+
+
+@app.get("/turns/{turn_id}/tool-calls")
+def get_tool_calls(turn_id: str, logger: LoggerDep) -> list[ToolCallLog]:
+    return logger.get_tool_calls(turn_id)
+
+
+@app.get("/turns/{turn_id}/memory-accesses")
+def get_memory_accesses(turn_id: str, logger: LoggerDep) -> list[MemoryAccessLog]:
+    return logger.get_memory_accesses(turn_id)
+
+
+@app.get("/turns/{turn_id}/avatar-events")
+def get_avatar_events(turn_id: str, logger: LoggerDep) -> list[AvatarEventLog]:
+    return logger.get_avatar_events(turn_id)

--- a/services/agent/src/agent/app.py
+++ b/services/agent/src/agent/app.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Annotated
 
-from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi import Depends, FastAPI, HTTPException, Query, status
 from pydantic import BaseModel
 
 from agent.config import settings
@@ -20,6 +20,8 @@ from agent.logger.interaction_logger import (
     ToolCallLog,
     TurnLog,
 )
+from agent.memory.profile import ProfileStore
+from agent.memory.store import Memory, MemoryStore, MemoryType, Task, TaskStatus
 
 app = FastAPI(title="avatar-agent", version="0.1.0")
 
@@ -31,6 +33,24 @@ def get_logger() -> InteractionLogger:
 
 
 LoggerDep = Annotated[InteractionLogger, Depends(get_logger)]
+
+
+@lru_cache
+def get_memory_store() -> MemoryStore:
+    """Return the process-wide long-term memory store (created on first use)."""
+    return MemoryStore(Path(settings.storage_dir) / "app.sqlite")
+
+
+MemoryStoreDep = Annotated[MemoryStore, Depends(get_memory_store)]
+
+
+@lru_cache
+def get_profile_store() -> ProfileStore:
+    """Return the process-wide profile store (storage/memory/profile.md)."""
+    return ProfileStore(Path(settings.storage_dir) / "memory" / "profile.md")
+
+
+ProfileStoreDep = Annotated[ProfileStore, Depends(get_profile_store)]
 
 
 class StartSessionRequest(BaseModel):
@@ -61,6 +81,39 @@ class FeedbackRequest(BaseModel):
     rating: int | None = None
     label: str | None = None
     comment: str | None = None
+
+
+class CreateMemoryRequest(BaseModel):
+    type: MemoryType
+    content: str
+    source: str | None = None
+    importance: int = 3
+    metadata: dict[str, object] | None = None
+
+
+class UpdateMemoryRequest(BaseModel):
+    content: str | None = None
+    importance: int | None = None
+    source: str | None = None
+    metadata: dict[str, object] | None = None
+
+
+class CreateTaskRequest(BaseModel):
+    title: str
+    status: TaskStatus = "todo"
+    due_date: str | None = None
+    content: str | None = None
+
+
+class UpdateTaskRequest(BaseModel):
+    title: str | None = None
+    status: TaskStatus | None = None
+    due_date: str | None = None
+    content: str | None = None
+
+
+class ProfileRequest(BaseModel):
+    content: str
 
 
 @app.get("/health")
@@ -160,3 +213,96 @@ def post_feedback(turn_id: str, req: FeedbackRequest, logger: LoggerDep) -> Expl
 @app.get("/turns/{turn_id}/feedback")
 def get_feedback(turn_id: str, logger: LoggerDep) -> list[ExplicitFeedbackLog]:
     return logger.get_feedback(turn_id)
+
+
+# ── Phase 12: long-term memory (memories / tasks / profile) ────────────────────
+
+
+@app.post("/memories", status_code=status.HTTP_201_CREATED)
+def create_memory(req: CreateMemoryRequest, store: MemoryStoreDep) -> Memory:
+    return store.add_memory(
+        req.type,
+        req.content,
+        source=req.source,
+        importance=req.importance,
+        metadata=req.metadata,
+    )
+
+
+@app.get("/memories")
+def search_memories(
+    store: MemoryStoreDep,
+    q: str | None = None,
+    memory_type: Annotated[MemoryType | None, Query(alias="type")] = None,
+    limit: int = 20,
+) -> list[Memory]:
+    return store.search_memories(q, memory_type=memory_type, limit=limit)
+
+
+@app.get("/memories/{memory_id}")
+def get_memory(memory_id: str, store: MemoryStoreDep) -> Memory:
+    memory = store.get_memory(memory_id)
+    if memory is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="memory not found")
+    return memory
+
+
+@app.patch("/memories/{memory_id}")
+def update_memory(memory_id: str, req: UpdateMemoryRequest, store: MemoryStoreDep) -> Memory:
+    updated = store.update_memory(
+        memory_id,
+        content=req.content,
+        importance=req.importance,
+        source=req.source,
+        metadata=req.metadata,
+    )
+    if updated is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="memory not found")
+    return updated
+
+
+@app.post("/memories/{memory_id}/supersede")
+def supersede_memory(memory_id: str, store: MemoryStoreDep) -> Memory:
+    store.supersede_memory(memory_id)
+    memory = store.get_memory(memory_id)
+    if memory is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="memory not found")
+    return memory
+
+
+@app.post("/tasks", status_code=status.HTTP_201_CREATED)
+def create_task(req: CreateTaskRequest, store: MemoryStoreDep) -> Task:
+    return store.add_task(req.title, status=req.status, due_date=req.due_date, content=req.content)
+
+
+@app.get("/tasks")
+def list_tasks(
+    store: MemoryStoreDep,
+    task_status: Annotated[TaskStatus | None, Query(alias="status")] = None,
+) -> list[Task]:
+    return store.list_tasks(status=task_status)
+
+
+@app.patch("/tasks/{task_id}")
+def update_task(task_id: str, req: UpdateTaskRequest, store: MemoryStoreDep) -> Task:
+    updated = store.update_task(
+        task_id,
+        title=req.title,
+        status=req.status,
+        due_date=req.due_date,
+        content=req.content,
+    )
+    if updated is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="task not found")
+    return updated
+
+
+@app.get("/profile")
+def get_profile(profile: ProfileStoreDep) -> dict[str, str]:
+    return {"content": profile.read()}
+
+
+@app.put("/profile")
+def put_profile(req: ProfileRequest, profile: ProfileStoreDep) -> dict[str, str]:
+    profile.write(req.content)
+    return {"content": profile.read()}

--- a/services/agent/src/agent/app.py
+++ b/services/agent/src/agent/app.py
@@ -2,14 +2,103 @@
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from functools import lru_cache
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import Depends, FastAPI, HTTPException, status
+from pydantic import BaseModel
 
 from agent.config import settings
+from agent.logger.interaction_logger import InteractionLogger, Session, TurnLog
 
 app = FastAPI(title="avatar-agent", version="0.1.0")
+
+
+@lru_cache
+def get_logger() -> InteractionLogger:
+    """Return the process-wide interaction logger (created on first use)."""
+    return InteractionLogger(Path(settings.storage_dir) / "app.sqlite")
+
+
+LoggerDep = Annotated[InteractionLogger, Depends(get_logger)]
+
+
+class StartSessionRequest(BaseModel):
+    model: str | None = None
+    title: str | None = None
+    app_version: str | None = None
+
+
+class LogTurnRequest(BaseModel):
+    user_input: str | None = None
+    assistant_output: str | None = None
+    raw_assistant_output: str | None = None
+    model: str | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    latency_ms: int | None = None
+    emotion: str | None = None
+    motion: str | None = None
+    status: str = "ok"
+    error: str | None = None
+
+
+class EndSessionRequest(BaseModel):
+    summary: str | None = None
 
 
 @app.get("/health")
 def health() -> dict[str, str]:
     """Liveness probe. Returns the active model so the UI can display it."""
     return {"status": "ok", "model": settings.ollama_model}
+
+
+@app.post("/sessions", status_code=status.HTTP_201_CREATED)
+def create_session(req: StartSessionRequest, logger: LoggerDep) -> Session:
+    return logger.start_session(model=req.model, title=req.title, app_version=req.app_version)
+
+
+@app.get("/sessions")
+def list_sessions(logger: LoggerDep) -> list[Session]:
+    return logger.list_sessions()
+
+
+@app.get("/sessions/{session_id}")
+def get_session(session_id: str, logger: LoggerDep) -> Session:
+    session = logger.get_session(session_id)
+    if session is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="session not found")
+    return session
+
+
+@app.post("/sessions/{session_id}/turns", status_code=status.HTTP_201_CREATED)
+def log_turn(session_id: str, req: LogTurnRequest, logger: LoggerDep) -> TurnLog:
+    return logger.log_turn(
+        session_id,
+        user_input=req.user_input,
+        assistant_output=req.assistant_output,
+        raw_assistant_output=req.raw_assistant_output,
+        model=req.model,
+        prompt_tokens=req.prompt_tokens,
+        completion_tokens=req.completion_tokens,
+        latency_ms=req.latency_ms,
+        emotion=req.emotion,
+        motion=req.motion,
+        status=req.status,
+        error=req.error,
+    )
+
+
+@app.get("/sessions/{session_id}/turns")
+def get_turns(session_id: str, logger: LoggerDep) -> list[TurnLog]:
+    return logger.get_turns(session_id)
+
+
+@app.post("/sessions/{session_id}/end")
+def end_session(session_id: str, req: EndSessionRequest, logger: LoggerDep) -> Session:
+    logger.end_session(session_id, summary=req.summary)
+    session = logger.get_session(session_id)
+    if session is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="session not found")
+    return session

--- a/services/agent/src/agent/app.py
+++ b/services/agent/src/agent/app.py
@@ -21,6 +21,7 @@ from agent.logger.interaction_logger import (
     TurnLog,
 )
 from agent.memory.profile import ProfileStore
+from agent.memory.retrieval import MemoryRetriever, ScoredMemory, build_context
 from agent.memory.store import Memory, MemoryStore, MemoryType, Task, TaskStatus
 
 app = FastAPI(title="avatar-agent", version="0.1.0")
@@ -51,6 +52,15 @@ def get_profile_store() -> ProfileStore:
 
 
 ProfileStoreDep = Annotated[ProfileStore, Depends(get_profile_store)]
+
+
+@lru_cache
+def get_retriever() -> MemoryRetriever:
+    """Return the process-wide memory retriever (created on first use)."""
+    return MemoryRetriever(Path(settings.storage_dir) / "app.sqlite", get_memory_store())
+
+
+RetrieverDep = Annotated[MemoryRetriever, Depends(get_retriever)]
 
 
 class StartSessionRequest(BaseModel):
@@ -114,6 +124,18 @@ class UpdateTaskRequest(BaseModel):
 
 class ProfileRequest(BaseModel):
     content: str
+
+
+class RetrieveRequest(BaseModel):
+    query: str
+    limit: int = 5
+    min_score: float = 0.0
+    turn_id: str | None = None
+
+
+class RetrieveResponse(BaseModel):
+    results: list[ScoredMemory]
+    context: str
 
 
 @app.get("/health")
@@ -306,3 +328,24 @@ def get_profile(profile: ProfileStoreDep) -> dict[str, str]:
 def put_profile(req: ProfileRequest, profile: ProfileStoreDep) -> dict[str, str]:
     profile.write(req.content)
     return {"content": profile.read()}
+
+
+# ── Phase 13: memory retrieval ─────────────────────────────────────────────────
+
+
+@app.post("/retrieve")
+def retrieve_memories(
+    req: RetrieveRequest,
+    store: MemoryStoreDep,
+    retriever: RetrieverDep,
+    logger: LoggerDep,
+) -> RetrieveResponse:
+    results = retriever.retrieve(
+        req.query,
+        limit=req.limit,
+        min_score=req.min_score,
+        logger=logger if req.turn_id else None,
+        turn_id=req.turn_id,
+    )
+    open_tasks = [*store.list_tasks(status="todo"), *store.list_tasks(status="in_progress")]
+    return RetrieveResponse(results=results, context=build_context(results, open_tasks))

--- a/services/agent/src/agent/config.py
+++ b/services/agent/src/agent/config.py
@@ -18,5 +18,9 @@ class Settings(BaseSettings):
     ollama_timeout_ms: int = 120_000
     storage_dir: str = "./storage"
 
+    # Memory retrieval embeddings (Phase 13). "hash" = offline/deterministic default.
+    embedding_backend: str = "hash"  # "hash" | "ollama"
+    embedding_model: str = "embeddinggemma"
+
 
 settings = Settings()

--- a/services/agent/src/agent/logger/db.py
+++ b/services/agent/src/agent/logger/db.py
@@ -42,6 +42,63 @@ CREATE TABLE IF NOT EXISTS turn_logs (
 
 CREATE INDEX IF NOT EXISTS idx_turn_logs_session
   ON turn_logs (session_id, turn_index);
+
+CREATE TABLE IF NOT EXISTS prompt_logs (
+  id             TEXT PRIMARY KEY,
+  turn_id        TEXT NOT NULL,
+  system_prompt  TEXT,
+  memory_context TEXT,
+  recent_context TEXT,
+  tool_context   TEXT,
+  final_prompt   TEXT,
+  created_at     TEXT NOT NULL,
+  FOREIGN KEY (turn_id) REFERENCES turn_logs (id)
+);
+
+CREATE TABLE IF NOT EXISTS tool_call_logs (
+  id          TEXT PRIMARY KEY,
+  turn_id     TEXT NOT NULL,
+  tool_name   TEXT NOT NULL,
+  input_json  TEXT,
+  output_json TEXT,
+  status      TEXT,
+  latency_ms  INTEGER,
+  error       TEXT,
+  created_at  TEXT NOT NULL,
+  FOREIGN KEY (turn_id) REFERENCES turn_logs (id)
+);
+
+CREATE TABLE IF NOT EXISTS memory_access_logs (
+  id               TEXT PRIMARY KEY,
+  turn_id          TEXT NOT NULL,
+  memory_id        TEXT,
+  access_type      TEXT NOT NULL,
+  relevance_score  REAL,
+  recency_score    REAL,
+  importance_score REAL,
+  final_score      REAL,
+  reason           TEXT,
+  created_at       TEXT NOT NULL,
+  FOREIGN KEY (turn_id) REFERENCES turn_logs (id)
+);
+
+CREATE TABLE IF NOT EXISTS avatar_event_logs (
+  id          TEXT PRIMARY KEY,
+  turn_id     TEXT NOT NULL,
+  emotion     TEXT,
+  motion      TEXT,
+  tts_enabled INTEGER,
+  tts_text    TEXT,
+  started_at  TEXT,
+  ended_at    TEXT,
+  created_at  TEXT NOT NULL,
+  FOREIGN KEY (turn_id) REFERENCES turn_logs (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_prompt_logs_turn ON prompt_logs (turn_id);
+CREATE INDEX IF NOT EXISTS idx_tool_call_logs_turn ON tool_call_logs (turn_id);
+CREATE INDEX IF NOT EXISTS idx_memory_access_logs_turn ON memory_access_logs (turn_id);
+CREATE INDEX IF NOT EXISTS idx_avatar_event_logs_turn ON avatar_event_logs (turn_id);
 """
 
 

--- a/services/agent/src/agent/logger/db.py
+++ b/services/agent/src/agent/logger/db.py
@@ -98,7 +98,18 @@ CREATE TABLE IF NOT EXISTS avatar_event_logs (
 CREATE INDEX IF NOT EXISTS idx_prompt_logs_turn ON prompt_logs (turn_id);
 CREATE INDEX IF NOT EXISTS idx_tool_call_logs_turn ON tool_call_logs (turn_id);
 CREATE INDEX IF NOT EXISTS idx_memory_access_logs_turn ON memory_access_logs (turn_id);
+CREATE TABLE IF NOT EXISTS explicit_feedback_logs (
+  id         TEXT PRIMARY KEY,
+  turn_id    TEXT NOT NULL,
+  rating     INTEGER,
+  label      TEXT,
+  comment    TEXT,
+  created_at TEXT NOT NULL,
+  FOREIGN KEY (turn_id) REFERENCES turn_logs (id)
+);
+
 CREATE INDEX IF NOT EXISTS idx_avatar_event_logs_turn ON avatar_event_logs (turn_id);
+CREATE INDEX IF NOT EXISTS idx_explicit_feedback_logs_turn ON explicit_feedback_logs (turn_id);
 """
 
 

--- a/services/agent/src/agent/logger/db.py
+++ b/services/agent/src/agent/logger/db.py
@@ -1,0 +1,60 @@
+"""SQLite schema and connection helpers for interaction logging."""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS sessions (
+  id          TEXT PRIMARY KEY,
+  title       TEXT,
+  started_at  TEXT NOT NULL,
+  ended_at    TEXT,
+  summary     TEXT,
+  model       TEXT,
+  app_version TEXT,
+  created_at  TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS turn_logs (
+  id                   TEXT PRIMARY KEY,
+  session_id           TEXT NOT NULL,
+  turn_index           INTEGER NOT NULL,
+  timestamp            TEXT NOT NULL,
+  user_input           TEXT,
+  assistant_output     TEXT,
+  raw_assistant_output TEXT,
+  model                TEXT,
+  prompt_tokens        INTEGER,
+  completion_tokens    INTEGER,
+  latency_ms           INTEGER,
+  emotion              TEXT,
+  motion               TEXT,
+  status               TEXT,
+  error                TEXT,
+  created_at           TEXT NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES sessions (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_turn_logs_session
+  ON turn_logs (session_id, turn_index);
+"""
+
+
+def connect(db_path: Path) -> sqlite3.Connection:
+    """Open a SQLite connection with row access by column name."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def init_db(conn: sqlite3.Connection) -> None:
+    """Create tables and indexes if they do not exist."""
+    conn.executescript(_SCHEMA)
+    conn.commit()

--- a/services/agent/src/agent/logger/interaction_logger.py
+++ b/services/agent/src/agent/logger/interaction_logger.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from contextlib import closing
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 from uuid import uuid4
 
 from pydantic import BaseModel
@@ -34,6 +34,36 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
 
 _NEXT_TURN_INDEX = "SELECT COALESCE(MAX(turn_index), -1) + 1 AS next FROM turn_logs WHERE session_id = ?"
+
+_INSERT_PROMPT = """
+INSERT INTO prompt_logs
+  (id, turn_id, system_prompt, memory_context, recent_context, tool_context,
+   final_prompt, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+_INSERT_TOOL_CALL = """
+INSERT INTO tool_call_logs
+  (id, turn_id, tool_name, input_json, output_json, status, latency_ms, error,
+   created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+_INSERT_MEMORY_ACCESS = """
+INSERT INTO memory_access_logs
+  (id, turn_id, memory_id, access_type, relevance_score, recency_score,
+   importance_score, final_score, reason, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+_INSERT_AVATAR_EVENT = """
+INSERT INTO avatar_event_logs
+  (id, turn_id, emotion, motion, tts_enabled, tts_text, started_at, ended_at,
+   created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+AccessType = Literal["read", "write", "update", "delete", "supersede"]
 
 
 def _now_iso() -> str:
@@ -75,6 +105,62 @@ class TurnLog(BaseModel):
     motion: str | None = None
     status: str = "ok"
     error: str | None = None
+    created_at: str
+
+
+class PromptLog(BaseModel):
+    """How a turn's prompt was assembled (system + memory + recent + tools)."""
+
+    id: str
+    turn_id: str
+    system_prompt: str | None = None
+    memory_context: str | None = None
+    recent_context: str | None = None
+    tool_context: str | None = None
+    final_prompt: str | None = None
+    created_at: str
+
+
+class ToolCallLog(BaseModel):
+    """A single tool invocation made while answering a turn."""
+
+    id: str
+    turn_id: str
+    tool_name: str
+    input_json: str | None = None
+    output_json: str | None = None
+    status: str = "ok"
+    latency_ms: int | None = None
+    error: str | None = None
+    created_at: str
+
+
+class MemoryAccessLog(BaseModel):
+    """A memory read/write/update made while answering a turn."""
+
+    id: str
+    turn_id: str
+    memory_id: str | None = None
+    access_type: AccessType
+    relevance_score: float | None = None
+    recency_score: float | None = None
+    importance_score: float | None = None
+    final_score: float | None = None
+    reason: str | None = None
+    created_at: str
+
+
+class AvatarEventLog(BaseModel):
+    """An avatar expression / TTS event emitted for a turn."""
+
+    id: str
+    turn_id: str
+    emotion: str | None = None
+    motion: str | None = None
+    tts_enabled: bool | None = None
+    tts_text: str | None = None
+    started_at: str | None = None
+    ended_at: str | None = None
     created_at: str
 
 
@@ -201,3 +287,193 @@ class InteractionLogger:
                 (session_id,),
             ).fetchall()
         return [TurnLog(**dict(row)) for row in rows]
+
+    # ── Phase 10: prompt / tool / memory-access / avatar logs ──────────────────
+
+    def log_prompt(
+        self,
+        turn_id: str,
+        *,
+        system_prompt: str | None = None,
+        memory_context: str | None = None,
+        recent_context: str | None = None,
+        tool_context: str | None = None,
+        final_prompt: str | None = None,
+    ) -> PromptLog:
+        log = PromptLog(
+            id=_new_id(),
+            turn_id=turn_id,
+            system_prompt=system_prompt,
+            memory_context=memory_context,
+            recent_context=recent_context,
+            tool_context=tool_context,
+            final_prompt=final_prompt,
+            created_at=_now_iso(),
+        )
+        with closing(connect(self._db_path)) as conn, conn:
+            conn.execute(
+                _INSERT_PROMPT,
+                (
+                    log.id,
+                    log.turn_id,
+                    log.system_prompt,
+                    log.memory_context,
+                    log.recent_context,
+                    log.tool_context,
+                    log.final_prompt,
+                    log.created_at,
+                ),
+            )
+        return log
+
+    def log_tool_call(
+        self,
+        turn_id: str,
+        tool_name: str,
+        *,
+        input_json: str | None = None,
+        output_json: str | None = None,
+        status: str = "ok",
+        latency_ms: int | None = None,
+        error: str | None = None,
+    ) -> ToolCallLog:
+        log = ToolCallLog(
+            id=_new_id(),
+            turn_id=turn_id,
+            tool_name=tool_name,
+            input_json=input_json,
+            output_json=output_json,
+            status=status,
+            latency_ms=latency_ms,
+            error=error,
+            created_at=_now_iso(),
+        )
+        with closing(connect(self._db_path)) as conn, conn:
+            conn.execute(
+                _INSERT_TOOL_CALL,
+                (
+                    log.id,
+                    log.turn_id,
+                    log.tool_name,
+                    log.input_json,
+                    log.output_json,
+                    log.status,
+                    log.latency_ms,
+                    log.error,
+                    log.created_at,
+                ),
+            )
+        return log
+
+    def log_memory_access(
+        self,
+        turn_id: str,
+        access_type: AccessType,
+        *,
+        memory_id: str | None = None,
+        relevance_score: float | None = None,
+        recency_score: float | None = None,
+        importance_score: float | None = None,
+        final_score: float | None = None,
+        reason: str | None = None,
+    ) -> MemoryAccessLog:
+        log = MemoryAccessLog(
+            id=_new_id(),
+            turn_id=turn_id,
+            memory_id=memory_id,
+            access_type=access_type,
+            relevance_score=relevance_score,
+            recency_score=recency_score,
+            importance_score=importance_score,
+            final_score=final_score,
+            reason=reason,
+            created_at=_now_iso(),
+        )
+        with closing(connect(self._db_path)) as conn, conn:
+            conn.execute(
+                _INSERT_MEMORY_ACCESS,
+                (
+                    log.id,
+                    log.turn_id,
+                    log.memory_id,
+                    log.access_type,
+                    log.relevance_score,
+                    log.recency_score,
+                    log.importance_score,
+                    log.final_score,
+                    log.reason,
+                    log.created_at,
+                ),
+            )
+        return log
+
+    def log_avatar_event(
+        self,
+        turn_id: str,
+        *,
+        emotion: str | None = None,
+        motion: str | None = None,
+        tts_enabled: bool | None = None,
+        tts_text: str | None = None,
+        started_at: str | None = None,
+        ended_at: str | None = None,
+    ) -> AvatarEventLog:
+        log = AvatarEventLog(
+            id=_new_id(),
+            turn_id=turn_id,
+            emotion=emotion,
+            motion=motion,
+            tts_enabled=tts_enabled,
+            tts_text=tts_text,
+            started_at=started_at,
+            ended_at=ended_at,
+            created_at=_now_iso(),
+        )
+        with closing(connect(self._db_path)) as conn, conn:
+            conn.execute(
+                _INSERT_AVATAR_EVENT,
+                (
+                    log.id,
+                    log.turn_id,
+                    log.emotion,
+                    log.motion,
+                    None if log.tts_enabled is None else int(log.tts_enabled),
+                    log.tts_text,
+                    log.started_at,
+                    log.ended_at,
+                    log.created_at,
+                ),
+            )
+        return log
+
+    def get_prompts(self, turn_id: str) -> list[PromptLog]:
+        with closing(connect(self._db_path)) as conn:
+            rows = conn.execute(
+                "SELECT * FROM prompt_logs WHERE turn_id = ? ORDER BY created_at",
+                (turn_id,),
+            ).fetchall()
+        return [PromptLog(**dict(row)) for row in rows]
+
+    def get_tool_calls(self, turn_id: str) -> list[ToolCallLog]:
+        with closing(connect(self._db_path)) as conn:
+            rows = conn.execute(
+                "SELECT * FROM tool_call_logs WHERE turn_id = ? ORDER BY created_at",
+                (turn_id,),
+            ).fetchall()
+        return [ToolCallLog(**dict(row)) for row in rows]
+
+    def get_memory_accesses(self, turn_id: str) -> list[MemoryAccessLog]:
+        with closing(connect(self._db_path)) as conn:
+            rows = conn.execute(
+                "SELECT * FROM memory_access_logs WHERE turn_id = ? ORDER BY created_at",
+                (turn_id,),
+            ).fetchall()
+        return [MemoryAccessLog(**dict(row)) for row in rows]
+
+    def get_avatar_events(self, turn_id: str) -> list[AvatarEventLog]:
+        with closing(connect(self._db_path)) as conn:
+            rows = conn.execute(
+                "SELECT * FROM avatar_event_logs WHERE turn_id = ? ORDER BY created_at",
+                (turn_id,),
+            ).fetchall()
+        return [AvatarEventLog(**dict(row)) for row in rows]

--- a/services/agent/src/agent/logger/interaction_logger.py
+++ b/services/agent/src/agent/logger/interaction_logger.py
@@ -12,7 +12,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Literal
 from uuid import uuid4
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from agent.logger.db import connect, init_db
 
@@ -63,7 +63,16 @@ INSERT INTO avatar_event_logs
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 """
 
+_INSERT_FEEDBACK = """
+INSERT INTO explicit_feedback_logs
+  (id, turn_id, rating, label, comment, created_at)
+VALUES (?, ?, ?, ?, ?, ?)
+"""
+
 AccessType = Literal["read", "write", "update", "delete", "supersede"]
+
+_RATING_MIN = 1
+_RATING_MAX = 5
 
 
 def _now_iso() -> str:
@@ -161,6 +170,17 @@ class AvatarEventLog(BaseModel):
     tts_text: str | None = None
     started_at: str | None = None
     ended_at: str | None = None
+    created_at: str
+
+
+class ExplicitFeedbackLog(BaseModel):
+    """User-supplied feedback on a turn (👍/👎 plus optional label/comment)."""
+
+    id: str
+    turn_id: str
+    rating: int | None = Field(default=None, ge=_RATING_MIN, le=_RATING_MAX)
+    label: str | None = None
+    comment: str | None = None
     created_at: str
 
 
@@ -477,3 +497,43 @@ class InteractionLogger:
                 (turn_id,),
             ).fetchall()
         return [AvatarEventLog(**dict(row)) for row in rows]
+
+    # ── Phase 11: explicit feedback ────────────────────────────────────────────
+
+    def log_explicit_feedback(
+        self,
+        turn_id: str,
+        *,
+        rating: int | None = None,
+        label: str | None = None,
+        comment: str | None = None,
+    ) -> ExplicitFeedbackLog:
+        feedback = ExplicitFeedbackLog(
+            id=_new_id(),
+            turn_id=turn_id,
+            rating=rating,
+            label=label,
+            comment=comment,
+            created_at=_now_iso(),
+        )
+        with closing(connect(self._db_path)) as conn, conn:
+            conn.execute(
+                _INSERT_FEEDBACK,
+                (
+                    feedback.id,
+                    feedback.turn_id,
+                    feedback.rating,
+                    feedback.label,
+                    feedback.comment,
+                    feedback.created_at,
+                ),
+            )
+        return feedback
+
+    def get_feedback(self, turn_id: str) -> list[ExplicitFeedbackLog]:
+        with closing(connect(self._db_path)) as conn:
+            rows = conn.execute(
+                "SELECT * FROM explicit_feedback_logs WHERE turn_id = ? ORDER BY created_at",
+                (turn_id,),
+            ).fetchall()
+        return [ExplicitFeedbackLog(**dict(row)) for row in rows]

--- a/services/agent/src/agent/logger/interaction_logger.py
+++ b/services/agent/src/agent/logger/interaction_logger.py
@@ -1,0 +1,203 @@
+"""Interaction logging store backed by SQLite (Phase 9).
+
+Persists every session and turn verbatim — chat, casual talk, opinions, and
+complaints alike. This is the raw Interaction Log; promotion into long-term
+memory happens elsewhere.
+"""
+
+from __future__ import annotations
+
+from contextlib import closing
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+from agent.logger.db import connect, init_db
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_INSERT_SESSION = """
+INSERT INTO sessions
+  (id, title, started_at, ended_at, summary, model, app_version, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+_INSERT_TURN = """
+INSERT INTO turn_logs
+  (id, session_id, turn_index, timestamp, user_input, assistant_output,
+   raw_assistant_output, model, prompt_tokens, completion_tokens, latency_ms,
+   emotion, motion, status, error, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+_NEXT_TURN_INDEX = "SELECT COALESCE(MAX(turn_index), -1) + 1 AS next FROM turn_logs WHERE session_id = ?"
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=UTC).isoformat()
+
+
+def _new_id() -> str:
+    return uuid4().hex
+
+
+class Session(BaseModel):
+    """A conversation session."""
+
+    id: str
+    title: str | None = None
+    started_at: str
+    ended_at: str | None = None
+    summary: str | None = None
+    model: str | None = None
+    app_version: str | None = None
+    created_at: str
+
+
+class TurnLog(BaseModel):
+    """A single user/assistant exchange within a session."""
+
+    id: str
+    session_id: str
+    turn_index: int
+    timestamp: str
+    user_input: str | None = None
+    assistant_output: str | None = None
+    raw_assistant_output: str | None = None
+    model: str | None = None
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    latency_ms: int | None = None
+    emotion: str | None = None
+    motion: str | None = None
+    status: str = "ok"
+    error: str | None = None
+    created_at: str
+
+
+class InteractionLogger:
+    """Append-only logger that persists sessions and turns to SQLite."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        with closing(connect(db_path)) as conn:
+            init_db(conn)
+
+    def start_session(
+        self,
+        model: str | None = None,
+        title: str | None = None,
+        app_version: str | None = None,
+    ) -> Session:
+        now = _now_iso()
+        session = Session(
+            id=_new_id(),
+            title=title,
+            started_at=now,
+            model=model,
+            app_version=app_version,
+            created_at=now,
+        )
+        with closing(connect(self._db_path)) as conn, conn:
+            conn.execute(
+                _INSERT_SESSION,
+                (
+                    session.id,
+                    session.title,
+                    session.started_at,
+                    session.ended_at,
+                    session.summary,
+                    session.model,
+                    session.app_version,
+                    session.created_at,
+                ),
+            )
+        return session
+
+    def log_turn(
+        self,
+        session_id: str,
+        *,
+        user_input: str | None = None,
+        assistant_output: str | None = None,
+        raw_assistant_output: str | None = None,
+        model: str | None = None,
+        prompt_tokens: int | None = None,
+        completion_tokens: int | None = None,
+        latency_ms: int | None = None,
+        emotion: str | None = None,
+        motion: str | None = None,
+        status: str = "ok",
+        error: str | None = None,
+    ) -> TurnLog:
+        now = _now_iso()
+        with closing(connect(self._db_path)) as conn, conn:
+            row = conn.execute(_NEXT_TURN_INDEX, (session_id,)).fetchone()
+            turn = TurnLog(
+                id=_new_id(),
+                session_id=session_id,
+                turn_index=int(row["next"]),
+                timestamp=now,
+                user_input=user_input,
+                assistant_output=assistant_output,
+                raw_assistant_output=raw_assistant_output,
+                model=model,
+                prompt_tokens=prompt_tokens,
+                completion_tokens=completion_tokens,
+                latency_ms=latency_ms,
+                emotion=emotion,
+                motion=motion,
+                status=status,
+                error=error,
+                created_at=now,
+            )
+            conn.execute(
+                _INSERT_TURN,
+                (
+                    turn.id,
+                    turn.session_id,
+                    turn.turn_index,
+                    turn.timestamp,
+                    turn.user_input,
+                    turn.assistant_output,
+                    turn.raw_assistant_output,
+                    turn.model,
+                    turn.prompt_tokens,
+                    turn.completion_tokens,
+                    turn.latency_ms,
+                    turn.emotion,
+                    turn.motion,
+                    turn.status,
+                    turn.error,
+                    turn.created_at,
+                ),
+            )
+        return turn
+
+    def end_session(self, session_id: str, summary: str | None = None) -> None:
+        with closing(connect(self._db_path)) as conn, conn:
+            conn.execute(
+                "UPDATE sessions SET ended_at = ?, summary = COALESCE(?, summary) WHERE id = ?",
+                (_now_iso(), summary, session_id),
+            )
+
+    def get_session(self, session_id: str) -> Session | None:
+        with closing(connect(self._db_path)) as conn:
+            row = conn.execute("SELECT * FROM sessions WHERE id = ?", (session_id,)).fetchone()
+        return Session(**dict(row)) if row is not None else None
+
+    def list_sessions(self) -> list[Session]:
+        with closing(connect(self._db_path)) as conn:
+            rows = conn.execute("SELECT * FROM sessions ORDER BY started_at DESC").fetchall()
+        return [Session(**dict(row)) for row in rows]
+
+    def get_turns(self, session_id: str) -> list[TurnLog]:
+        with closing(connect(self._db_path)) as conn:
+            rows = conn.execute(
+                "SELECT * FROM turn_logs WHERE session_id = ? ORDER BY turn_index",
+                (session_id,),
+            ).fetchall()
+        return [TurnLog(**dict(row)) for row in rows]

--- a/services/agent/src/agent/memory/db.py
+++ b/services/agent/src/agent/memory/db.py
@@ -1,0 +1,49 @@
+"""SQLite schema for long-term memory (Phase 12).
+
+Memories and tasks live in the same app.sqlite as the interaction logs so that
+memory_access_logs can reference a memory id. Profile is a separate Markdown
+document (see profile.py) representing the user's current state.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import sqlite3
+
+_MEMORY_SCHEMA = """
+CREATE TABLE IF NOT EXISTS memories (
+  id               TEXT PRIMARY KEY,
+  type             TEXT NOT NULL,
+  content          TEXT NOT NULL,
+  source           TEXT,
+  importance       INTEGER NOT NULL DEFAULT 3,
+  created_at       TEXT NOT NULL,
+  updated_at       TEXT NOT NULL,
+  last_accessed_at TEXT,
+  embedding_id     TEXT,
+  metadata         TEXT,
+  superseded       INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE INDEX IF NOT EXISTS idx_memories_type ON memories (type);
+
+CREATE TABLE IF NOT EXISTS tasks (
+  id         TEXT PRIMARY KEY,
+  title      TEXT NOT NULL,
+  status     TEXT NOT NULL DEFAULT 'todo',
+  due_date   TEXT,
+  content    TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks (status);
+"""
+
+
+def init_memory_db(conn: sqlite3.Connection) -> None:
+    """Create memory/task tables and indexes if they do not exist."""
+    conn.executescript(_MEMORY_SCHEMA)
+    conn.commit()

--- a/services/agent/src/agent/memory/embeddings.py
+++ b/services/agent/src/agent/memory/embeddings.py
@@ -1,0 +1,79 @@
+"""Embedding backends (Phase 13).
+
+Pluggable so retrieval stays testable without a running model:
+- HashEmbedder: deterministic, dependency-free. Default; used in tests/offline.
+- OllamaEmbedder: real semantic embeddings via Ollama (EmbeddingGemma etc.).
+
+The production path is OllamaEmbedder; HashEmbedder is a token-overlap stand-in.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from typing import Protocol, runtime_checkable
+
+import httpx
+
+from agent.config import settings
+
+_HASH_DIM = 256
+_EMBED_TIMEOUT_S = 30.0
+
+
+@runtime_checkable
+class Embedder(Protocol):
+    """Maps texts to fixed-length vectors."""
+
+    def embed(self, texts: list[str]) -> list[list[float]]: ...
+
+
+def _normalize(vec: list[float]) -> list[float]:
+    norm = math.sqrt(sum(x * x for x in vec))
+    if norm == 0:
+        return vec
+    return [x / norm for x in vec]
+
+
+class HashEmbedder:
+    """Deterministic bag-of-tokens hashing embedder (no external dependency)."""
+
+    def __init__(self, dim: int = _HASH_DIM) -> None:
+        self._dim = dim
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        return [self._embed_one(text) for text in texts]
+
+    def _embed_one(self, text: str) -> list[float]:
+        vec = [0.0] * self._dim
+        for token in text.lower().split():
+            digest = hashlib.sha1(token.encode("utf-8")).digest()  # noqa: S324 (non-crypto use)
+            bucket = int.from_bytes(digest[:4], "big") % self._dim
+            sign = 1.0 if digest[4] & 1 else -1.0
+            vec[bucket] += sign
+        return _normalize(vec)
+
+
+class OllamaEmbedder:
+    """Semantic embeddings via Ollama's /api/embed endpoint."""
+
+    def __init__(self, base_url: str, model: str) -> None:
+        self._base_url = base_url
+        self._model = model
+
+    def embed(self, texts: list[str]) -> list[list[float]]:
+        res = httpx.post(
+            f"{self._base_url}/api/embed",
+            json={"model": self._model, "input": texts},
+            timeout=_EMBED_TIMEOUT_S,
+        )
+        res.raise_for_status()
+        data = res.json()
+        return [_normalize(vec) for vec in data["embeddings"]]
+
+
+def get_embedder() -> Embedder:
+    """Return the configured embedder (hash by default, ollama when requested)."""
+    if settings.embedding_backend == "ollama":
+        return OllamaEmbedder(settings.ollama_base_url, settings.embedding_model)
+    return HashEmbedder()

--- a/services/agent/src/agent/memory/profile.py
+++ b/services/agent/src/agent/memory/profile.py
@@ -1,0 +1,31 @@
+"""Profile memory (Phase 12).
+
+The profile is a single Markdown document representing the user's *current*
+state (呼び名・口調・研究テーマ・禁止事項 等). Unlike episodic memory it is
+overwritten in place: it always reflects the latest truth.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class ProfileStore:
+    """Read/write access to the profile Markdown document."""
+
+    def __init__(self, profile_path: Path) -> None:
+        self._path = profile_path
+
+    def read(self) -> str:
+        """Return the profile text, or an empty string if it does not exist yet."""
+        if not self._path.exists():
+            return ""
+        return self._path.read_text(encoding="utf-8")
+
+    def write(self, content: str) -> None:
+        """Overwrite the profile document (current truth)."""
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(content, encoding="utf-8")

--- a/services/agent/src/agent/memory/retrieval.py
+++ b/services/agent/src/agent/memory/retrieval.py
@@ -1,0 +1,164 @@
+"""Memory retrieval (Phase 13).
+
+Ranks long-term memories for a query by a weighted blend of:
+  final = WR*relevance + WC*recency + WI*importance
+where relevance is cosine similarity over (pluggable) embeddings. Embeddings are
+cached per memory in `memory_embeddings`. Retrieved memories can be logged to
+memory_access_logs and formatted for prompt injection.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import closing
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+from agent.logger.db import connect
+from agent.memory.embeddings import get_embedder
+
+# Runtime import (not TYPE_CHECKING): pydantic resolves `Memory` as a field type at runtime.
+from agent.memory.store import Memory  # noqa: TC001
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from agent.logger.interaction_logger import InteractionLogger
+    from agent.memory.embeddings import Embedder
+    from agent.memory.store import MemoryStore, Task
+
+_WEIGHT_RELEVANCE = 0.6
+_WEIGHT_RECENCY = 0.2
+_WEIGHT_IMPORTANCE = 0.2
+_RECENCY_HALF_LIFE_DAYS = 14.0
+_IMPORTANCE_MAX = 5
+_CANDIDATE_LIMIT = 500
+_DEFAULT_TOP_K = 5
+_SECONDS_PER_DAY = 86_400.0
+
+_CREATE_EMBEDDINGS = """
+CREATE TABLE IF NOT EXISTS memory_embeddings (
+  memory_id TEXT PRIMARY KEY,
+  dim       INTEGER NOT NULL,
+  vector    TEXT NOT NULL
+)
+"""
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    # Embedders return normalized vectors, so the dot product is the cosine.
+    return sum(x * y for x, y in zip(a, b, strict=False))
+
+
+class ScoredMemory(BaseModel):
+    """A memory with its retrieval scores."""
+
+    memory: Memory
+    relevance: float
+    recency: float
+    importance: float
+    final: float
+
+
+class MemoryRetriever:
+    """Embedding-based retrieval over the long-term memory store."""
+
+    def __init__(self, db_path: Path, store: MemoryStore, embedder: Embedder | None = None) -> None:
+        self._db_path = db_path
+        self._store = store
+        self._embedder = embedder if embedder is not None else get_embedder()
+        with closing(connect(db_path)) as conn, conn:
+            conn.execute(_CREATE_EMBEDDINGS)
+
+    def retrieve(
+        self,
+        query: str,
+        *,
+        limit: int = _DEFAULT_TOP_K,
+        min_score: float = 0.0,
+        logger: InteractionLogger | None = None,
+        turn_id: str | None = None,
+    ) -> list[ScoredMemory]:
+        memories = self._store.search_memories(limit=_CANDIDATE_LIMIT)
+        if not memories:
+            return []
+
+        vectors = self._ensure_embeddings(memories)
+        query_vec = self._embedder.embed([query])[0]
+        now = datetime.now(tz=UTC)
+
+        scored: list[ScoredMemory] = []
+        for memory in memories:
+            relevance = max(0.0, _cosine(query_vec, vectors[memory.id]))
+            recency = self._recency(memory.updated_at, now)
+            importance = memory.importance / _IMPORTANCE_MAX
+            final = _WEIGHT_RELEVANCE * relevance + _WEIGHT_RECENCY * recency + _WEIGHT_IMPORTANCE * importance
+            if final >= min_score:
+                scored.append(
+                    ScoredMemory(
+                        memory=memory,
+                        relevance=relevance,
+                        recency=recency,
+                        importance=importance,
+                        final=final,
+                    ),
+                )
+
+        scored.sort(key=lambda s: s.final, reverse=True)
+        top = scored[:limit]
+
+        if logger is not None and turn_id is not None:
+            for sm in top:
+                logger.log_memory_access(
+                    turn_id,
+                    "read",
+                    memory_id=sm.memory.id,
+                    relevance_score=sm.relevance,
+                    recency_score=sm.recency,
+                    importance_score=sm.importance,
+                    final_score=sm.final,
+                    reason="retrieved for query",
+                )
+        return top
+
+    @staticmethod
+    def _recency(updated_at: str, now: datetime) -> float:
+        try:
+            updated = datetime.fromisoformat(updated_at)
+        except ValueError:
+            return 0.0
+        age_days = max(0.0, (now - updated).total_seconds() / _SECONDS_PER_DAY)
+        return 0.5 ** (age_days / _RECENCY_HALF_LIFE_DAYS)
+
+    def _ensure_embeddings(self, memories: list[Memory]) -> dict[str, list[float]]:
+        with closing(connect(self._db_path)) as conn:
+            rows = conn.execute("SELECT memory_id, vector FROM memory_embeddings").fetchall()
+        cached: dict[str, list[float]] = {row["memory_id"]: json.loads(row["vector"]) for row in rows}
+
+        missing = [m for m in memories if m.id not in cached]
+        if missing:
+            new_vectors = self._embedder.embed([m.content for m in missing])
+            with closing(connect(self._db_path)) as conn, conn:
+                for memory, vec in zip(missing, new_vectors, strict=True):
+                    conn.execute(
+                        "INSERT OR REPLACE INTO memory_embeddings (memory_id, dim, vector) VALUES (?, ?, ?)",
+                        (memory.id, len(vec), json.dumps(vec)),
+                    )
+                    cached[memory.id] = vec
+        return cached
+
+
+def build_context(scored: list[ScoredMemory], tasks: list[Task] | None = None) -> str:
+    """Format retrieved memories (+ open tasks) for system-prompt injection."""
+    lines: list[str] = []
+    if scored:
+        lines.append("# 関連する記憶")
+        lines.extend(f"- {sm.memory.content}" for sm in scored)
+    if tasks:
+        if lines:
+            lines.append("")
+        lines.append("# 現在のタスク")
+        lines.extend(f"- [{task.status}] {task.title}" for task in tasks)
+    return "\n".join(lines)

--- a/services/agent/src/agent/memory/store.py
+++ b/services/agent/src/agent/memory/store.py
@@ -1,0 +1,274 @@
+"""Long-term memory store: memories + tasks (Phase 12).
+
+v1 uses SQLite with keyword (substring) search ordered by importance and
+recency. Vector / embedding search and relevance·recency·importance scoring are
+deferred to Phase 13 (Memory Retrieval); `embedding_id` is reserved for that.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import closing
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Literal
+from uuid import uuid4
+
+from pydantic import BaseModel, Field
+
+from agent.logger.db import connect  # shared SQLite connection helper
+from agent.memory.db import init_memory_db
+
+if TYPE_CHECKING:
+    import sqlite3
+    from pathlib import Path
+
+MemoryType = Literal["semantic", "episodic", "procedural", "archival"]
+TaskStatus = Literal["todo", "in_progress", "done", "blocked", "cancelled"]
+
+_IMPORTANCE_MIN = 1
+_IMPORTANCE_MAX = 5
+_DEFAULT_IMPORTANCE = 3
+_DEFAULT_SEARCH_LIMIT = 20
+
+_INSERT_MEMORY = """
+INSERT INTO memories
+  (id, type, content, source, importance, created_at, updated_at,
+   last_accessed_at, embedding_id, metadata, superseded)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+"""
+
+# Fixed query with optional filters handled via `? IS NULL OR ...` (no dynamic SQL).
+_SEARCH_MEMORIES = """
+SELECT * FROM memories
+WHERE (? IS NULL OR type = ?)
+  AND (? IS NULL OR content LIKE ?)
+  AND (superseded = 0 OR ? = 1)
+ORDER BY importance DESC, updated_at DESC
+LIMIT ?
+"""
+
+_UPDATE_MEMORY = """
+UPDATE memories SET
+  content = COALESCE(?, content),
+  importance = COALESCE(?, importance),
+  source = COALESCE(?, source),
+  metadata = COALESCE(?, metadata),
+  updated_at = ?
+WHERE id = ?
+"""
+
+_INSERT_TASK = """
+INSERT INTO tasks (id, title, status, due_date, content, created_at, updated_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+"""
+
+_UPDATE_TASK = """
+UPDATE tasks SET
+  title = COALESCE(?, title),
+  status = COALESCE(?, status),
+  due_date = COALESCE(?, due_date),
+  content = COALESCE(?, content),
+  updated_at = ?
+WHERE id = ?
+"""
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=UTC).isoformat()
+
+
+def _new_id() -> str:
+    return uuid4().hex
+
+
+class Memory(BaseModel):
+    """A unit of long-term memory (semantic/episodic/procedural/archival)."""
+
+    id: str
+    type: MemoryType
+    content: str
+    source: str | None = None
+    importance: int = Field(default=_DEFAULT_IMPORTANCE, ge=_IMPORTANCE_MIN, le=_IMPORTANCE_MAX)
+    created_at: str
+    updated_at: str
+    last_accessed_at: str | None = None
+    embedding_id: str | None = None
+    metadata: dict[str, object] | None = None
+    superseded: bool = False
+
+
+class Task(BaseModel):
+    """A tracked task / todo with a lifecycle status."""
+
+    id: str
+    title: str
+    status: TaskStatus = "todo"
+    due_date: str | None = None
+    content: str | None = None
+    created_at: str
+    updated_at: str
+
+
+def _row_to_memory(row: sqlite3.Row) -> Memory:
+    data = dict(row)
+    raw_metadata = data.pop("metadata", None)
+    data["metadata"] = json.loads(raw_metadata) if raw_metadata else None
+    data["superseded"] = bool(data["superseded"])
+    return Memory(**data)
+
+
+class MemoryStore:
+    """Long-term memory storage backed by SQLite (memories + tasks)."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        with closing(connect(db_path)) as conn:
+            init_memory_db(conn)
+
+    # ── Memories ───────────────────────────────────────────────────────────────
+
+    def add_memory(
+        self,
+        memory_type: MemoryType,
+        content: str,
+        *,
+        source: str | None = None,
+        importance: int = _DEFAULT_IMPORTANCE,
+        metadata: dict[str, object] | None = None,
+    ) -> Memory:
+        now = _now_iso()
+        memory = Memory(
+            id=_new_id(),
+            type=memory_type,
+            content=content,
+            source=source,
+            importance=importance,
+            created_at=now,
+            updated_at=now,
+            metadata=metadata,
+        )
+        with closing(connect(self._db_path)) as conn, conn:
+            conn.execute(
+                _INSERT_MEMORY,
+                (
+                    memory.id,
+                    memory.type,
+                    memory.content,
+                    memory.source,
+                    memory.importance,
+                    memory.created_at,
+                    memory.updated_at,
+                    memory.last_accessed_at,
+                    memory.embedding_id,
+                    json.dumps(metadata) if metadata is not None else None,
+                ),
+            )
+        return memory
+
+    def get_memory(self, memory_id: str) -> Memory | None:
+        with closing(connect(self._db_path)) as conn:
+            row = conn.execute("SELECT * FROM memories WHERE id = ?", (memory_id,)).fetchone()
+        return _row_to_memory(row) if row is not None else None
+
+    def search_memories(
+        self,
+        query: str | None = None,
+        *,
+        memory_type: MemoryType | None = None,
+        include_superseded: bool = False,
+        limit: int = _DEFAULT_SEARCH_LIMIT,
+    ) -> list[Memory]:
+        like = f"%{query}%" if query else None
+        with closing(connect(self._db_path)) as conn:
+            rows = conn.execute(
+                _SEARCH_MEMORIES,
+                (memory_type, memory_type, query, like, int(include_superseded), limit),
+            ).fetchall()
+        return [_row_to_memory(row) for row in rows]
+
+    def update_memory(
+        self,
+        memory_id: str,
+        *,
+        content: str | None = None,
+        importance: int | None = None,
+        source: str | None = None,
+        metadata: dict[str, object] | None = None,
+    ) -> Memory | None:
+        with closing(connect(self._db_path)) as conn, conn:
+            conn.execute(
+                _UPDATE_MEMORY,
+                (
+                    content,
+                    importance,
+                    source,
+                    json.dumps(metadata) if metadata is not None else None,
+                    _now_iso(),
+                    memory_id,
+                ),
+            )
+        return self.get_memory(memory_id)
+
+    def supersede_memory(self, memory_id: str) -> None:
+        """Mark a memory as superseded (kept for history, hidden from search)."""
+        with closing(connect(self._db_path)) as conn, conn:
+            conn.execute(
+                "UPDATE memories SET superseded = 1, updated_at = ? WHERE id = ?",
+                (_now_iso(), memory_id),
+            )
+
+    # ── Tasks ──────────────────────────────────────────────────────────────────
+
+    def add_task(
+        self,
+        title: str,
+        *,
+        status: TaskStatus = "todo",
+        due_date: str | None = None,
+        content: str | None = None,
+    ) -> Task:
+        now = _now_iso()
+        task = Task(
+            id=_new_id(),
+            title=title,
+            status=status,
+            due_date=due_date,
+            content=content,
+            created_at=now,
+            updated_at=now,
+        )
+        with closing(connect(self._db_path)) as conn, conn:
+            conn.execute(
+                _INSERT_TASK,
+                (task.id, task.title, task.status, task.due_date, task.content, task.created_at, task.updated_at),
+            )
+        return task
+
+    def get_task(self, task_id: str) -> Task | None:
+        with closing(connect(self._db_path)) as conn:
+            row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+        return Task(**dict(row)) if row is not None else None
+
+    def list_tasks(self, *, status: TaskStatus | None = None) -> list[Task]:
+        with closing(connect(self._db_path)) as conn:
+            rows = conn.execute(
+                "SELECT * FROM tasks WHERE (? IS NULL OR status = ?) ORDER BY created_at DESC",
+                (status, status),
+            ).fetchall()
+        return [Task(**dict(row)) for row in rows]
+
+    def update_task(
+        self,
+        task_id: str,
+        *,
+        title: str | None = None,
+        status: TaskStatus | None = None,
+        due_date: str | None = None,
+        content: str | None = None,
+    ) -> Task | None:
+        with closing(connect(self._db_path)) as conn, conn:
+            conn.execute(
+                _UPDATE_TASK,
+                (title, status, due_date, content, _now_iso(), task_id),
+            )
+        return self.get_task(task_id)

--- a/services/agent/tests/api_logging_test.py
+++ b/services/agent/tests/api_logging_test.py
@@ -37,3 +37,22 @@ def test_session_and_turn_roundtrip(client: TestClient) -> None:
 
 def test_get_unknown_session_returns_404(client: TestClient) -> None:
     assert client.get("/sessions/does-not-exist").status_code == 404
+
+
+def test_turn_event_logs_readable_via_api(client: TestClient, tmp_path: Path) -> None:
+    session_id = client.post("/sessions", json={"model": "gemma4:31b"}).json()["id"]
+    turn_id = client.post(f"/sessions/{session_id}/turns", json={"user_input": "やあ"}).json()["id"]
+
+    # Event logs are written in-process; share the same DB file the API uses.
+    logger = InteractionLogger(tmp_path / "app.sqlite")
+    logger.log_tool_call(turn_id, "filesystem.list", status="ok")
+    logger.log_memory_access(turn_id, "read", memory_id="m1")
+
+    calls = client.get(f"/turns/{turn_id}/tool-calls")
+    assert calls.status_code == 200
+    assert len(calls.json()) == 1
+    assert calls.json()[0]["tool_name"] == "filesystem.list"
+
+    accesses = client.get(f"/turns/{turn_id}/memory-accesses")
+    assert accesses.status_code == 200
+    assert accesses.json()[0]["access_type"] == "read"

--- a/services/agent/tests/api_logging_test.py
+++ b/services/agent/tests/api_logging_test.py
@@ -1,0 +1,39 @@
+"""API-level tests for the interaction logging endpoints (Phase 9)."""
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agent.app import app, get_logger
+from agent.logger.interaction_logger import InteractionLogger
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> Iterator[TestClient]:
+    app.dependency_overrides[get_logger] = lambda: InteractionLogger(tmp_path / "app.sqlite")
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_session_and_turn_roundtrip(client: TestClient) -> None:
+    created = client.post("/sessions", json={"model": "gemma4:31b"})
+    assert created.status_code == 201
+    session_id = created.json()["id"]
+
+    turn = client.post(
+        f"/sessions/{session_id}/turns",
+        json={"user_input": "やあ", "assistant_output": "こんにちは", "emotion": "happy"},
+    )
+    assert turn.status_code == 201
+    assert turn.json()["turn_index"] == 0
+
+    turns = client.get(f"/sessions/{session_id}/turns")
+    assert turns.status_code == 200
+    assert len(turns.json()) == 1
+    assert turns.json()[0]["assistant_output"] == "こんにちは"
+
+
+def test_get_unknown_session_returns_404(client: TestClient) -> None:
+    assert client.get("/sessions/does-not-exist").status_code == 404

--- a/services/agent/tests/api_memory_test.py
+++ b/services/agent/tests/api_memory_test.py
@@ -1,0 +1,46 @@
+"""API-level tests for the memory / task / profile endpoints (Phase 12)."""
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agent.app import app, get_memory_store, get_profile_store
+from agent.memory.profile import ProfileStore
+from agent.memory.store import MemoryStore
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> Iterator[TestClient]:
+    app.dependency_overrides[get_memory_store] = lambda: MemoryStore(tmp_path / "app.sqlite")
+    app.dependency_overrides[get_profile_store] = lambda: ProfileStore(tmp_path / "memory" / "profile.md")
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_memory_create_and_search(client: TestClient) -> None:
+    created = client.post("/memories", json={"type": "semantic", "content": "知識編集を研究", "importance": 5})
+    assert created.status_code == 201
+
+    hits = client.get("/memories", params={"q": "研究"})
+    assert hits.status_code == 200
+    assert len(hits.json()) == 1
+    assert hits.json()[0]["importance"] == 5
+
+
+def test_task_create_and_filter(client: TestClient) -> None:
+    created = client.post("/tasks", json={"title": "ログ基盤を実装"})
+    assert created.status_code == 201
+    task_id = created.json()["id"]
+
+    client.patch(f"/tasks/{task_id}", json={"status": "in_progress"})
+    listed = client.get("/tasks", params={"status": "in_progress"})
+    assert listed.status_code == 200
+    assert len(listed.json()) == 1
+
+
+def test_profile_roundtrip(client: TestClient) -> None:
+    assert client.get("/profile").json()["content"] == ""
+    client.put("/profile", json={"content": "# Profile\n- 呼び名: 石垣さん\n"})
+    assert "石垣さん" in client.get("/profile").json()["content"]

--- a/services/agent/tests/event_logs_test.py
+++ b/services/agent/tests/event_logs_test.py
@@ -1,0 +1,66 @@
+"""Tests for Phase 10 logs: prompt / tool / memory-access / avatar."""
+
+from pathlib import Path
+
+from agent.logger.interaction_logger import InteractionLogger
+
+
+def _turn(logger: InteractionLogger) -> str:
+    session = logger.start_session(model="gemma4:31b")
+    return logger.log_turn(session.id, user_input="やあ", assistant_output="どうも").id
+
+
+def test_prompt_log_records_construction(tmp_path: Path) -> None:
+    logger = InteractionLogger(tmp_path / "app.sqlite")
+    turn_id = _turn(logger)
+    logger.log_prompt(
+        turn_id,
+        system_prompt="あなたはアリス",
+        memory_context="名前: 田中",
+        final_prompt="...",
+    )
+    prompts = logger.get_prompts(turn_id)
+    assert len(prompts) == 1
+    assert prompts[0].turn_id == turn_id
+    assert prompts[0].memory_context == "名前: 田中"
+
+
+def test_tool_calls_are_logged_in_order(tmp_path: Path) -> None:
+    logger = InteractionLogger(tmp_path / "app.sqlite")
+    turn_id = _turn(logger)
+    logger.log_tool_call(turn_id, "filesystem.list", input_json='{"path": "."}', status="ok")
+    logger.log_tool_call(turn_id, "filesystem.read", status="error", error="not found")
+
+    calls = logger.get_tool_calls(turn_id)
+    assert [c.tool_name for c in calls] == ["filesystem.list", "filesystem.read"]
+    assert calls[1].status == "error"
+    assert calls[1].error == "not found"
+
+
+def test_memory_access_log_keeps_scores_and_type(tmp_path: Path) -> None:
+    logger = InteractionLogger(tmp_path / "app.sqlite")
+    turn_id = _turn(logger)
+    logger.log_memory_access(
+        turn_id,
+        "read",
+        memory_id="m1",
+        relevance_score=0.8,
+        final_score=0.7,
+        reason="similar to query",
+    )
+    accesses = logger.get_memory_accesses(turn_id)
+    assert len(accesses) == 1
+    assert accesses[0].access_type == "read"
+    assert accesses[0].relevance_score == 0.8
+
+
+def test_avatar_event_roundtrips_bool_flag(tmp_path: Path) -> None:
+    logger = InteractionLogger(tmp_path / "app.sqlite")
+    turn_id = _turn(logger)
+    logger.log_avatar_event(turn_id, emotion="happy", motion="nod", tts_enabled=True, tts_text="どうも")
+
+    events = logger.get_avatar_events(turn_id)
+    assert len(events) == 1
+    # tts_enabled is stored as INTEGER but must come back as a bool.
+    assert events[0].tts_enabled is True
+    assert events[0].emotion == "happy"

--- a/services/agent/tests/explicit_feedback_test.py
+++ b/services/agent/tests/explicit_feedback_test.py
@@ -1,0 +1,39 @@
+"""Tests for Phase 11 explicit feedback logging."""
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from agent.logger.interaction_logger import InteractionLogger
+
+
+def _turn(logger: InteractionLogger) -> str:
+    session = logger.start_session(model="gemma4:31b")
+    return logger.log_turn(session.id, user_input="やあ", assistant_output="どうも").id
+
+
+def test_feedback_is_recorded_and_readable(tmp_path: Path) -> None:
+    logger = InteractionLogger(tmp_path / "app.sqlite")
+    turn_id = _turn(logger)
+    logger.log_explicit_feedback(turn_id, rating=2, label="too_shallow", comment="もっと具体的に")
+
+    feedback = logger.get_feedback(turn_id)
+    assert len(feedback) == 1
+    assert feedback[0].rating == 2
+    assert feedback[0].label == "too_shallow"
+    assert feedback[0].comment == "もっと具体的に"
+
+
+def test_thumbs_up_without_comment(tmp_path: Path) -> None:
+    logger = InteractionLogger(tmp_path / "app.sqlite")
+    turn_id = _turn(logger)
+    logger.log_explicit_feedback(turn_id, rating=5, label="helpful")
+    assert logger.get_feedback(turn_id)[0].comment is None
+
+
+def test_rating_out_of_range_is_rejected(tmp_path: Path) -> None:
+    logger = InteractionLogger(tmp_path / "app.sqlite")
+    turn_id = _turn(logger)
+    with pytest.raises(ValidationError):
+        logger.log_explicit_feedback(turn_id, rating=9)

--- a/services/agent/tests/interaction_logger_test.py
+++ b/services/agent/tests/interaction_logger_test.py
@@ -1,0 +1,57 @@
+"""Tests for the SQLite-backed interaction logger (Phase 9)."""
+
+from pathlib import Path
+
+from agent.logger.interaction_logger import InteractionLogger
+
+
+def test_logs_all_turns_including_casual_talk(tmp_path: Path) -> None:
+    db = tmp_path / "app.sqlite"
+    logger = InteractionLogger(db)
+
+    session = logger.start_session(model="gemma4:31b", title="test")
+    logger.log_turn(
+        session.id,
+        user_input="今日やること整理して",
+        assistant_output="まずは…",
+        model="gemma4:31b",
+        latency_ms=1200,
+    )
+    # Casual chat / opinions must be stored too, not just task requests.
+    logger.log_turn(session.id, user_input="昨日見た映画、微妙だった", assistant_output="そうなんだ", emotion="sad")
+    logger.log_turn(session.id, user_input="今の回答ちょっと違う", assistant_output="ごめん、直すね", status="ok")
+
+    turns = logger.get_turns(session.id)
+    assert len(turns) == 3
+    # turn_index is assigned sequentially from 0.
+    assert [t.turn_index for t in turns] == [0, 1, 2]
+    assert turns[1].user_input == "昨日見た映画、微妙だった"
+    assert turns[0].model == "gemma4:31b"
+    assert turns[0].latency_ms == 1200
+
+
+def test_persists_across_logger_instances(tmp_path: Path) -> None:
+    db = tmp_path / "app.sqlite"
+    first = InteractionLogger(db)
+    session = first.start_session(model="gemma4:31b")
+    first.log_turn(session.id, user_input="覚えておいて")
+    first.end_session(session.id, summary="短い雑談")
+
+    # A fresh instance on the same file must see the persisted data.
+    second = InteractionLogger(db)
+    reloaded = second.get_session(session.id)
+    assert reloaded is not None
+    assert reloaded.ended_at is not None
+    assert reloaded.summary == "短い雑談"
+    assert len(second.get_turns(session.id)) == 1
+
+
+def test_sessions_are_listed_independently(tmp_path: Path) -> None:
+    logger = InteractionLogger(tmp_path / "app.sqlite")
+    a = logger.start_session(model="gemma4:31b")
+    b = logger.start_session(model="gemma4:12b")
+    logger.log_turn(a.id, user_input="A-1")
+
+    ids = {s.id for s in logger.list_sessions()}
+    assert {a.id, b.id} <= ids
+    assert logger.get_turns(b.id) == []

--- a/services/agent/tests/memory_store_test.py
+++ b/services/agent/tests/memory_store_test.py
@@ -1,0 +1,64 @@
+"""Tests for the long-term memory store: memories + tasks (Phase 12)."""
+
+from pathlib import Path
+
+from agent.memory.store import MemoryStore
+
+
+def test_memory_search_by_keyword_and_type(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "app.sqlite")
+    store.add_memory("semantic", "ユーザーは知識編集を研究している", importance=5)
+    store.add_memory("semantic", "ユーザーはコーヒーが好き", importance=2)
+    store.add_memory("episodic", "今日は要件定義を相談した")
+
+    hits = store.search_memories("研究")
+    assert len(hits) == 1
+    assert "知識編集" in hits[0].content
+
+    semantic = store.search_memories(memory_type="semantic")
+    assert len(semantic) == 2
+    # Ordered by importance DESC.
+    assert semantic[0].importance == 5
+
+
+def test_memory_update_and_persistence(tmp_path: Path) -> None:
+    db = tmp_path / "app.sqlite"
+    first = MemoryStore(db)
+    mem = first.add_memory("semantic", "Windows を使っている", metadata={"confidence": "low"})
+
+    updated = first.update_memory(mem.id, content="Linux を使っている", importance=4)
+    assert updated is not None
+    assert updated.content == "Linux を使っている"
+    assert updated.importance == 4
+    # Untouched field preserved via COALESCE.
+    assert updated.metadata == {"confidence": "low"}
+
+    reloaded = MemoryStore(db).get_memory(mem.id)
+    assert reloaded is not None
+    assert reloaded.content == "Linux を使っている"
+
+
+def test_superseded_memory_hidden_from_search(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path / "app.sqlite")
+    mem = store.add_memory("semantic", "古い事実")
+    store.supersede_memory(mem.id)
+
+    assert store.search_memories("古い") == []
+    assert store.search_memories("古い", include_superseded=True)[0].id == mem.id
+
+
+def test_tasks_lifecycle_and_persistence(tmp_path: Path) -> None:
+    db = tmp_path / "app.sqlite"
+    store = MemoryStore(db)
+    task = store.add_task("Interaction Logging を実装", due_date="2026-06-20")
+    assert task.status == "todo"
+
+    store.update_task(task.id, status="in_progress")
+    store.add_task("memory schema を設計", status="done")
+
+    todo = store.list_tasks(status="in_progress")
+    assert len(todo) == 1
+    assert todo[0].title == "Interaction Logging を実装"
+
+    # Survives restart.
+    assert len(MemoryStore(db).list_tasks()) == 2

--- a/services/agent/tests/profile_test.py
+++ b/services/agent/tests/profile_test.py
@@ -1,0 +1,22 @@
+"""Tests for profile memory (Phase 12)."""
+
+from pathlib import Path
+
+from agent.memory.profile import ProfileStore
+
+
+def test_profile_read_default_empty(tmp_path: Path) -> None:
+    profile = ProfileStore(tmp_path / "memory" / "profile.md")
+    assert profile.read() == ""
+
+
+def test_profile_write_then_read_and_overwrite(tmp_path: Path) -> None:
+    path = tmp_path / "memory" / "profile.md"
+    profile = ProfileStore(path)
+    profile.write("# Profile\n- 呼び名: 石垣さん\n")
+    assert "石垣さん" in profile.read()
+
+    # Profile is current truth: overwrite replaces.
+    profile.write("# Profile\n- 呼び名: 石垣さん\n- 口調: カジュアル\n")
+    reloaded = ProfileStore(path).read()
+    assert "口調: カジュアル" in reloaded

--- a/services/agent/tests/retrieval_test.py
+++ b/services/agent/tests/retrieval_test.py
@@ -1,0 +1,70 @@
+"""Tests for memory retrieval (Phase 13), using the deterministic HashEmbedder."""
+
+from pathlib import Path
+
+from agent.logger.interaction_logger import InteractionLogger
+from agent.memory.embeddings import HashEmbedder
+from agent.memory.retrieval import MemoryRetriever, build_context
+from agent.memory.store import MemoryStore
+
+
+def _retriever(tmp_path: Path) -> tuple[MemoryStore, MemoryRetriever]:
+    db = tmp_path / "app.sqlite"
+    store = MemoryStore(db)
+    retriever = MemoryRetriever(db, store, embedder=HashEmbedder())
+    return store, retriever
+
+
+def test_relevant_memory_ranks_first(tmp_path: Path) -> None:
+    store, retriever = _retriever(tmp_path)
+    store.add_memory("semantic", "ユーザー は 知識 編集 を 研究 している")
+    store.add_memory("semantic", "ユーザー は コーヒー が 好き")
+
+    results = retriever.retrieve("知識 編集 の 研究", limit=5)
+    assert results
+    assert "知識" in results[0].memory.content
+    # Scores are populated.
+    assert results[0].relevance > 0
+    assert 0.0 <= results[0].final <= 1.0
+
+
+def test_limit_caps_results(tmp_path: Path) -> None:
+    store, retriever = _retriever(tmp_path)
+    for i in range(6):
+        store.add_memory("semantic", f"事実 番号 {i}")
+    assert len(retriever.retrieve("事実", limit=3)) == 3
+
+
+def test_empty_store_returns_nothing(tmp_path: Path) -> None:
+    _store, retriever = _retriever(tmp_path)
+    assert retriever.retrieve("なんでも") == []
+
+
+def test_retrieval_writes_memory_access_logs(tmp_path: Path) -> None:
+    db = tmp_path / "app.sqlite"
+    store = MemoryStore(db)
+    retriever = MemoryRetriever(db, store, embedder=HashEmbedder())
+    logger = InteractionLogger(db)
+    session = logger.start_session(model="gemma4:31b")
+    turn_id = logger.log_turn(session.id, user_input="研究の話").id
+
+    store.add_memory("semantic", "知識 編集 の 研究")
+    results = retriever.retrieve("知識 編集", limit=5, logger=logger, turn_id=turn_id)
+    assert results
+
+    accesses = logger.get_memory_accesses(turn_id)
+    assert len(accesses) == len(results)
+    assert accesses[0].access_type == "read"
+    assert accesses[0].final_score is not None
+
+
+def test_build_context_includes_memories_and_tasks(tmp_path: Path) -> None:
+    store, retriever = _retriever(tmp_path)
+    store.add_memory("semantic", "知識 編集 の 研究")
+    store.add_task("ログ基盤を実装", status="in_progress")
+
+    results = retriever.retrieve("研究", limit=5)
+    context = build_context(results, store.list_tasks(status="in_progress"))
+    assert "関連する記憶" in context
+    assert "現在のタスク" in context
+    assert "ログ基盤を実装" in context


### PR DESCRIPTION
Python backend (services/agent) に観測・記憶基盤を導入する。要件定義 v2 の MVP コア前半。

## 含まれるフェーズ
- **Phase 9** Interaction Logging v1（sessions / turn_logs）— Closes #50
- **Phase 10** Prompt / Tool / Memory-access / Avatar ログ — Closes #51
- **Phase 11** Explicit Feedback（backend + UI 👍/👎/📝 + bridge↔agent 連携）— Closes #52
- **Phase 12** Long-term Memory v1（memories / tasks / profile）— Closes #53
- **Phase 13** Memory Retrieval（relevance·recency·importance ランキング、pluggable embeddings）— Closes #54

## 検証
- Python: ruff / ruff format / pytest **28 passed**（ローカル）。pyproject は固定。
- TS/Electron（Phase 11）: ローカルに node_modules が無く未コンパイル。本PRの CI typecheck が初検証。UI 挙動は `pnpm dev:all` で手動確認推奨。

## 構成
ハイブリッド: 新規バックエンドは Python（FastAPI + uv + ruff + pytest）、UI は Electron(TS) 維持。bridge↔agent-service は best-effort（service 停止時も会話継続）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)