### PR TITLE
feat: Memory Write / Consolidation (Phase 14)

### DIFF
--- a/services/agent/src/agent/app.py
+++ b/services/agent/src/agent/app.py
@@ -23,6 +23,7 @@ from agent.logger.interaction_logger import (
 from agent.memory.profile import ProfileStore
 from agent.memory.retrieval import MemoryRetriever, ScoredMemory, build_context
 from agent.memory.store import Memory, MemoryStore, MemoryType, Task, TaskStatus
+from agent.memory.writer import LLMExtractor, MemoryWriter
 
 app = FastAPI(title="avatar-agent", version="0.1.0")
 
@@ -61,6 +62,15 @@ def get_retriever() -> MemoryRetriever:
 
 
 RetrieverDep = Annotated[MemoryRetriever, Depends(get_retriever)]
+
+
+@lru_cache
+def get_memory_writer() -> MemoryWriter:
+    """Return the process-wide memory writer (created on first use)."""
+    return MemoryWriter(get_memory_store())
+
+
+MemoryWriterDep = Annotated[MemoryWriter, Depends(get_memory_writer)]
 
 
 class StartSessionRequest(BaseModel):
@@ -136,6 +146,16 @@ class RetrieveRequest(BaseModel):
 class RetrieveResponse(BaseModel):
     results: list[ScoredMemory]
     context: str
+
+
+class ExplicitWriteRequest(BaseModel):
+    text: str
+    turn_id: str | None = None
+
+
+class ExtractRequest(BaseModel):
+    conversation: str
+    turn_id: str | None = None
 
 
 @app.get("/health")
@@ -349,3 +369,28 @@ def retrieve_memories(
     )
     open_tasks = [*store.list_tasks(status="todo"), *store.list_tasks(status="in_progress")]
     return RetrieveResponse(results=results, context=build_context(results, open_tasks))
+
+
+# ── Phase 14: memory write / consolidation ─────────────────────────────────────
+
+
+@app.post("/memory-write/explicit")
+def write_explicit(req: ExplicitWriteRequest, writer: MemoryWriterDep, logger: LoggerDep) -> Memory | None:
+    return writer.write_explicit(
+        req.text,
+        logger=logger if req.turn_id else None,
+        turn_id=req.turn_id,
+    )
+
+
+@app.post("/memory-write/consolidate")
+def consolidate_memories(writer: MemoryWriterDep) -> dict[str, int]:
+    return {"merged": writer.consolidate_duplicates()}
+
+
+@app.post("/memory-write/extract")
+def extract_and_write(req: ExtractRequest, writer: MemoryWriterDep, logger: LoggerDep) -> list[Memory]:
+    # Uses the LLM extractor (requires Ollama); returns [] best-effort if unavailable.
+    extractor = LLMExtractor(settings.ollama_base_url, settings.ollama_model)
+    ops = extractor.extract(req.conversation)
+    return writer.apply(ops, logger=logger if req.turn_id else None, turn_id=req.turn_id)

--- a/services/agent/src/agent/memory/writer.py
+++ b/services/agent/src/agent/memory/writer.py
@@ -1,0 +1,198 @@
+"""Memory write & consolidation (Phase 14).
+
+Turns conversation into long-term memory:
+- Hot path: explicit "覚えて" requests are saved immediately (deterministic).
+- Background: a pluggable extractor proposes CREATE/UPDATE/DELETE/NOOP ops
+  (LLMExtractor uses Ollama; inject a fake in tests). apply() executes them.
+- Consolidation: near-duplicate memories are merged (older superseded).
+All writes are recorded to memory_access_logs when a logger + turn_id are given.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING, Literal, Protocol, runtime_checkable
+
+import httpx
+from pydantic import BaseModel
+
+from agent.memory.embeddings import get_embedder
+from agent.memory.store import MemoryType  # noqa: TC001  (pydantic field type, resolved at runtime)
+
+if TYPE_CHECKING:
+    from agent.logger.interaction_logger import InteractionLogger
+    from agent.memory.embeddings import Embedder
+    from agent.memory.store import Memory, MemoryStore
+
+_EXPLICIT_PATTERNS = (
+    re.compile(r"覚え(て|とい?て|ておい?て|ておいて)"),
+    re.compile(r"記憶し(て|ておいて)"),
+    re.compile(r"メモし(て|ておいて)"),
+)
+_EXPLICIT_IMPORTANCE = 5
+_DEDUP_THRESHOLD = 0.97
+_MIN_MEMORIES_TO_DEDUP = 2
+_EXTRACT_TIMEOUT_S = 60.0
+
+Operation = Literal["CREATE", "UPDATE", "DELETE", "NOOP"]
+_ACCESS_FOR_OP: dict[Operation, Literal["write", "update", "delete"]] = {
+    "CREATE": "write",
+    "UPDATE": "update",
+    "DELETE": "delete",
+}
+
+
+class MemoryOperation(BaseModel):
+    """A proposed change to long-term memory."""
+
+    operation: Operation
+    memory_type: MemoryType = "semantic"
+    content: str = ""
+    target_id: str | None = None
+    reason: str | None = None
+
+
+@runtime_checkable
+class MemoryExtractor(Protocol):
+    """Proposes memory operations from a conversation snippet."""
+
+    def extract(self, conversation: str) -> list[MemoryOperation]: ...
+
+
+def is_explicit_memory_request(text: str) -> bool:
+    """True if the user explicitly asked to remember something."""
+    return any(pattern.search(text) for pattern in _EXPLICIT_PATTERNS)
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    return sum(x * y for x, y in zip(a, b, strict=False))
+
+
+class MemoryWriter:
+    """Applies memory operations and consolidates duplicates."""
+
+    def __init__(self, store: MemoryStore, embedder: Embedder | None = None) -> None:
+        self._store = store
+        self._embedder = embedder if embedder is not None else get_embedder()
+
+    def write_explicit(
+        self,
+        text: str,
+        *,
+        logger: InteractionLogger | None = None,
+        turn_id: str | None = None,
+    ) -> Memory | None:
+        """Hot path: save the user's text verbatim when they asked to remember it."""
+        if not is_explicit_memory_request(text):
+            return None
+        memory = self._store.add_memory(
+            "semantic",
+            text.strip(),
+            source="explicit",
+            importance=_EXPLICIT_IMPORTANCE,
+        )
+        self._log(logger, turn_id, "write", memory.id, "explicit memory request")
+        return memory
+
+    def apply(
+        self,
+        operations: list[MemoryOperation],
+        *,
+        logger: InteractionLogger | None = None,
+        turn_id: str | None = None,
+    ) -> list[Memory]:
+        """Execute extractor-proposed operations; returns created/updated memories."""
+        applied: list[Memory] = []
+        for op in operations:
+            memory = self._apply_one(op)
+            if memory is not None:
+                applied.append(memory)
+            access = _ACCESS_FOR_OP.get(op.operation)
+            target = memory.id if memory is not None else op.target_id
+            if access is not None and target is not None:
+                self._log(logger, turn_id, access, target, op.reason)
+        return applied
+
+    def _apply_one(self, op: MemoryOperation) -> Memory | None:
+        if op.operation == "CREATE" and op.content:
+            return self._store.add_memory(op.memory_type, op.content, source="extracted")
+        if op.operation == "UPDATE" and op.target_id:
+            return self._store.update_memory(op.target_id, content=op.content or None)
+        if op.operation == "DELETE" and op.target_id:
+            self._store.supersede_memory(op.target_id)
+        return None
+
+    def consolidate_duplicates(self, *, threshold: float = _DEDUP_THRESHOLD) -> int:
+        """Supersede near-duplicate memories, keeping the most recent of each pair."""
+        memories = self._store.search_memories(limit=500)
+        if len(memories) < _MIN_MEMORIES_TO_DEDUP:
+            return 0
+        vectors = self._embedder.embed([m.content for m in memories])
+        # Most recent first so we keep the newest and supersede older duplicates.
+        order = sorted(range(len(memories)), key=lambda i: memories[i].updated_at, reverse=True)
+        kept: list[int] = []
+        merged = 0
+        for i in order:
+            if any(_cosine(vectors[i], vectors[k]) >= threshold for k in kept):
+                self._store.supersede_memory(memories[i].id)
+                merged += 1
+            else:
+                kept.append(i)
+        return merged
+
+    def _log(
+        self,
+        logger: InteractionLogger | None,
+        turn_id: str | None,
+        access_type: Literal["write", "update", "delete"],
+        memory_id: str,
+        reason: str | None,
+    ) -> None:
+        if logger is not None and turn_id is not None:
+            logger.log_memory_access(turn_id, access_type, memory_id=memory_id, reason=reason)
+
+
+class LLMExtractor:
+    """Extracts memory operations via Ollama (opt-in; requires a running model)."""
+
+    _SYSTEM = (
+        "会話から長期記憶に保存すべき情報を抽出する。"
+        'JSON 配列のみを返す。各要素は {"operation":"CREATE|UPDATE|DELETE|NOOP",'
+        '"memory_type":"semantic|episodic|procedural|archival","content":"...",'
+        '"reason":"..."}。保存価値がなければ [] を返す。'
+    )
+
+    def __init__(self, base_url: str, model: str) -> None:
+        self._base_url = base_url
+        self._model = model
+
+    def extract(self, conversation: str) -> list[MemoryOperation]:
+        try:
+            res = httpx.post(
+                f"{self._base_url}/api/chat",
+                json={
+                    "model": self._model,
+                    "stream": False,
+                    "format": "json",
+                    "messages": [
+                        {"role": "system", "content": self._SYSTEM},
+                        {"role": "user", "content": conversation},
+                    ],
+                },
+                timeout=_EXTRACT_TIMEOUT_S,
+            )
+            res.raise_for_status()
+            content = res.json()["message"]["content"]
+            parsed = json.loads(content)
+        except (httpx.HTTPError, KeyError, json.JSONDecodeError):
+            return []
+        items = parsed if isinstance(parsed, list) else parsed.get("operations", [])
+        ops: list[MemoryOperation] = []
+        for item in items:
+            try:
+                ops.append(MemoryOperation.model_validate(item))
+            except ValueError:
+                # Skip malformed items, keep the rest.
+                continue
+        return ops

--- a/services/agent/tests/writer_test.py
+++ b/services/agent/tests/writer_test.py
@@ -1,0 +1,84 @@
+"""Tests for memory write & consolidation (Phase 14)."""
+
+from pathlib import Path
+
+from agent.logger.interaction_logger import InteractionLogger
+from agent.memory.embeddings import HashEmbedder
+from agent.memory.store import MemoryStore
+from agent.memory.writer import MemoryOperation, MemoryWriter, is_explicit_memory_request
+
+
+def _writer(tmp_path: Path) -> tuple[MemoryStore, MemoryWriter]:
+    db = tmp_path / "app.sqlite"
+    store = MemoryStore(db)
+    return store, MemoryWriter(store, embedder=HashEmbedder())
+
+
+def test_explicit_request_detection() -> None:
+    assert is_explicit_memory_request("コーヒーが好きって覚えておいて")
+    assert is_explicit_memory_request("これメモして")
+    assert not is_explicit_memory_request("今日はいい天気だね")
+
+
+def test_write_explicit_saves_high_importance_memory(tmp_path: Path) -> None:
+    _store, writer = _writer(tmp_path)
+    saved = writer.write_explicit("私はコーヒーが好き、覚えておいて")
+    assert saved is not None
+    assert saved.importance == 5
+    assert saved.source == "explicit"
+    assert "コーヒー" in saved.content
+    # Non-explicit input writes nothing.
+    assert writer.write_explicit("こんにちは") is None
+
+
+def test_apply_operations_create_update_delete_noop(tmp_path: Path) -> None:
+    store, writer = _writer(tmp_path)
+    seed = store.add_memory("semantic", "Windows を使っている")
+
+    ops = [
+        MemoryOperation(operation="CREATE", content="知識編集を研究している"),
+        MemoryOperation(operation="UPDATE", target_id=seed.id, content="Linux を使っている"),
+        MemoryOperation(operation="NOOP", content="どうでもいい雑談"),
+    ]
+    applied = writer.apply(ops)
+    assert len(applied) == 2  # CREATE + UPDATE return memories, NOOP does not
+
+    contents = {m.content for m in store.search_memories(limit=50)}
+    assert "知識編集を研究している" in contents
+    assert "Linux を使っている" in contents
+    assert "Windows を使っている" not in contents  # updated in place
+
+
+def test_delete_supersedes_memory(tmp_path: Path) -> None:
+    store, writer = _writer(tmp_path)
+    mem = store.add_memory("semantic", "古い事実")
+    writer.apply([MemoryOperation(operation="DELETE", target_id=mem.id)])
+    assert store.search_memories("古い") == []
+    assert store.get_memory(mem.id) is not None  # kept for history
+
+
+def test_consolidate_merges_duplicates(tmp_path: Path) -> None:
+    store, writer = _writer(tmp_path)
+    store.add_memory("semantic", "ユーザー は コーヒー が 好き")
+    store.add_memory("semantic", "ユーザー は コーヒー が 好き")  # duplicate
+    store.add_memory("semantic", "ユーザー は 紅茶 が 好き")  # distinct
+
+    merged = writer.consolidate_duplicates()
+    assert merged == 1
+    # One of the duplicates remains active; the distinct one stays.
+    active = store.search_memories(limit=50)
+    assert len(active) == 2
+
+
+def test_write_logs_memory_access(tmp_path: Path) -> None:
+    db = tmp_path / "app.sqlite"
+    store = MemoryStore(db)
+    writer = MemoryWriter(store, embedder=HashEmbedder())
+    logger = InteractionLogger(db)
+    session = logger.start_session(model="gemma4:31b")
+    turn_id = logger.log_turn(session.id, user_input="覚えておいて").id
+
+    writer.write_explicit("コーヒーが好き、覚えておいて", logger=logger, turn_id=turn_id)
+    accesses = logger.get_memory_accesses(turn_id)
+    assert len(accesses) == 1
+    assert accesses[0].access_type == "write"


### PR DESCRIPTION
会話から長期記憶を抽出・統合する。Closes #55

## 内容
- `MemoryWriter.write_explicit`: 「覚えて/記憶して/メモして」を検出し即時保存（hot path, importance 5）
- `apply`: CREATE/UPDATE/DELETE/NOOP を適用（DELETE は superseded で履歴保持）
- `consolidate_duplicates`: 埋め込み類似度で重複を統合（新しい方を残す）
- 書き込みは memory_access_logs に記録
- `LLMExtractor`（Ollama, opt-in）: 雑談からの好み抽出
- API: `/memory-write/explicit` · `/consolidate` · `/extract`

## 検証
ruff / format / pytest **34 passed**（ローカル）。pyproject 固定。
LLMExtractor の実品質は Ollama での手動確認が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)