### PR TITLE
feat: Interaction Analytics v1 (Phase 15)

### DIFF
--- a/services/agent/src/agent/analytics/analyzer.py
+++ b/services/agent/src/agent/analytics/analyzer.py
@@ -1,0 +1,128 @@
+"""Satisfaction / dissatisfaction inference (Phase 15).
+
+RuleAnalyzer (default) scans the user's turn for correction / re-question /
+negative phrases and a latency signal — deterministic and testable. LLMAnalyzer
+(opt-in, Ollama) is the richer estimator. Both produce an `Analysis` that is
+persisted to inferred_feedback_logs.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Protocol, runtime_checkable
+
+import httpx
+from pydantic import BaseModel
+
+# (substring, issue_type). Order matters: more specific phrases first.
+_NEGATIVE_SIGNALS: tuple[tuple[str, str], ...] = (
+    ("そうじゃない", "misunderstanding"),
+    ("違う", "misunderstanding"),
+    ("もっと具体的", "too_abstract"),
+    ("浅い", "shallow_answer"),
+    ("長すぎ", "too_verbose"),
+    ("前にも言った", "ignored_context"),
+    ("前に言った", "ignored_context"),
+    ("それは不要", "over_automation"),
+    ("いらない", "over_automation"),
+    ("何言ってる", "misunderstanding"),
+    ("やり直し", "misunderstanding"),
+    ("やり直して", "misunderstanding"),
+    ("もういい", "shallow_answer"),
+)
+_POSITIVE_SIGNALS: tuple[str, ...] = ("いいね", "助かる", "それでOK", "ありがとう", "完璧", "ばっちり")
+
+_NEUTRAL_SCORE = 0.6
+_NEG_WEIGHT = 0.3
+_POS_WEIGHT = 0.3
+_LATENCY_PENALTY = 0.1
+_LATENCY_THRESHOLD_MS = 30_000
+_CONFIDENCE_WITH_SIGNAL = 0.7
+_CONFIDENCE_NO_SIGNAL = 0.3
+_LLM_TIMEOUT_S = 60.0
+
+
+class Analysis(BaseModel):
+    """The inferred outcome of a single turn."""
+
+    predicted_satisfaction: float
+    issue_type: str | None = None
+    issue_detail: str | None = None
+    evidence: str | None = None
+    confidence: float
+
+
+@runtime_checkable
+class Analyzer(Protocol):
+    """Infers satisfaction/issues for a user turn."""
+
+    def analyze(self, user_input: str, *, latency_ms: int | None = None) -> Analysis: ...
+
+
+def _clamp01(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+class RuleAnalyzer:
+    """Deterministic phrase/latency-based satisfaction inference."""
+
+    def analyze(self, user_input: str, *, latency_ms: int | None = None) -> Analysis:
+        negatives = [(phrase, issue) for phrase, issue in _NEGATIVE_SIGNALS if phrase in user_input]
+        positives = [phrase for phrase in _POSITIVE_SIGNALS if phrase in user_input]
+
+        score = _NEUTRAL_SCORE + _POS_WEIGHT * len(positives) - _NEG_WEIGHT * len(negatives)
+        issue_type: str | None = None
+        evidence: str | None = None
+        if negatives:
+            evidence, issue_type = negatives[0]
+
+        if latency_ms is not None and latency_ms > _LATENCY_THRESHOLD_MS:
+            score -= _LATENCY_PENALTY
+            if issue_type is None:
+                issue_type = "latency"
+                evidence = f"latency={latency_ms}ms"
+
+        has_signal = bool(negatives or positives)
+        return Analysis(
+            predicted_satisfaction=_clamp01(score),
+            issue_type=issue_type,
+            evidence=evidence,
+            confidence=_CONFIDENCE_WITH_SIGNAL if has_signal else _CONFIDENCE_NO_SIGNAL,
+        )
+
+
+class LLMAnalyzer:
+    """Richer satisfaction inference via Ollama (opt-in; requires a running model)."""
+
+    _SYSTEM = (
+        "直近のユーザー発話から、前の応答へのユーザー満足度を推定する。"
+        'JSON のみを返す: {"predicted_satisfaction":0..1,"issue_type":"...|null",'
+        '"issue_detail":"...","evidence":"...","confidence":0..1}。'
+    )
+
+    def __init__(self, base_url: str, model: str) -> None:
+        self._base_url = base_url
+        self._model = model
+        self._fallback = RuleAnalyzer()
+
+    def analyze(self, user_input: str, *, latency_ms: int | None = None) -> Analysis:
+        try:
+            res = httpx.post(
+                f"{self._base_url}/api/chat",
+                json={
+                    "model": self._model,
+                    "stream": False,
+                    "format": "json",
+                    "messages": [
+                        {"role": "system", "content": self._SYSTEM},
+                        {"role": "user", "content": user_input},
+                    ],
+                },
+                timeout=_LLM_TIMEOUT_S,
+            )
+            res.raise_for_status()
+            data = json.loads(res.json()["message"]["content"])
+            return Analysis.model_validate(data)
+        except (httpx.HTTPError, KeyError, json.JSONDecodeError, ValueError):
+            # Fall back to deterministic rules if the model is unavailable/malformed.
+            return self._fallback.analyze(user_input, latency_ms=latency_ms)

--- a/services/agent/src/agent/analytics/db.py
+++ b/services/agent/src/agent/analytics/db.py
@@ -1,0 +1,31 @@
+"""SQLite schema for interaction analytics (Phase 15)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import sqlite3
+
+_ANALYTICS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS inferred_feedback_logs (
+  id                     TEXT PRIMARY KEY,
+  turn_id                TEXT NOT NULL,
+  predicted_satisfaction REAL,
+  issue_type             TEXT,
+  issue_detail           TEXT,
+  evidence               TEXT,
+  confidence             REAL,
+  created_at             TEXT NOT NULL,
+  FOREIGN KEY (turn_id) REFERENCES turn_logs (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_inferred_feedback_turn ON inferred_feedback_logs (turn_id);
+CREATE INDEX IF NOT EXISTS idx_inferred_feedback_issue ON inferred_feedback_logs (issue_type);
+"""
+
+
+def init_analytics_db(conn: sqlite3.Connection) -> None:
+    """Create the inferred_feedback_logs table and indexes if absent."""
+    conn.executescript(_ANALYTICS_SCHEMA)
+    conn.commit()

--- a/services/agent/src/agent/analytics/store.py
+++ b/services/agent/src/agent/analytics/store.py
@@ -1,0 +1,89 @@
+"""Persistence for inferred feedback (Phase 15)."""
+
+from __future__ import annotations
+
+from contextlib import closing
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from pydantic import BaseModel
+
+from agent.analytics.db import init_analytics_db
+from agent.logger.db import connect
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from agent.analytics.analyzer import Analysis
+
+_INSERT_INFERRED = """
+INSERT INTO inferred_feedback_logs
+  (id, turn_id, predicted_satisfaction, issue_type, issue_detail, evidence, confidence, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+
+class InferredFeedbackLog(BaseModel):
+    """A stored inference about a turn's satisfaction."""
+
+    id: str
+    turn_id: str
+    predicted_satisfaction: float | None = None
+    issue_type: str | None = None
+    issue_detail: str | None = None
+    evidence: str | None = None
+    confidence: float | None = None
+    created_at: str
+
+
+class AnalyticsStore:
+    """Stores and queries inferred feedback."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        with closing(connect(db_path)) as conn:
+            init_analytics_db(conn)
+
+    def record(self, turn_id: str, analysis: Analysis) -> InferredFeedbackLog:
+        log = InferredFeedbackLog(
+            id=uuid4().hex,
+            turn_id=turn_id,
+            predicted_satisfaction=analysis.predicted_satisfaction,
+            issue_type=analysis.issue_type,
+            issue_detail=analysis.issue_detail,
+            evidence=analysis.evidence,
+            confidence=analysis.confidence,
+            created_at=datetime.now(tz=UTC).isoformat(),
+        )
+        with closing(connect(self._db_path)) as conn, conn:
+            conn.execute(
+                _INSERT_INFERRED,
+                (
+                    log.id,
+                    log.turn_id,
+                    log.predicted_satisfaction,
+                    log.issue_type,
+                    log.issue_detail,
+                    log.evidence,
+                    log.confidence,
+                    log.created_at,
+                ),
+            )
+        return log
+
+    def get_for_turn(self, turn_id: str) -> list[InferredFeedbackLog]:
+        with closing(connect(self._db_path)) as conn:
+            rows = conn.execute(
+                "SELECT * FROM inferred_feedback_logs WHERE turn_id = ? ORDER BY created_at",
+                (turn_id,),
+            ).fetchall()
+        return [InferredFeedbackLog(**dict(row)) for row in rows]
+
+    def issue_type_counts(self) -> dict[str, int]:
+        with closing(connect(self._db_path)) as conn:
+            rows = conn.execute(
+                "SELECT issue_type, COUNT(*) AS n FROM inferred_feedback_logs "
+                "WHERE issue_type IS NOT NULL GROUP BY issue_type ORDER BY n DESC",
+            ).fetchall()
+        return {row["issue_type"]: row["n"] for row in rows}

--- a/services/agent/src/agent/app.py
+++ b/services/agent/src/agent/app.py
@@ -9,6 +9,8 @@ from typing import Annotated
 from fastapi import Depends, FastAPI, HTTPException, Query, status
 from pydantic import BaseModel
 
+from agent.analytics.analyzer import Analyzer, LLMAnalyzer, RuleAnalyzer
+from agent.analytics.store import AnalyticsStore, InferredFeedbackLog
 from agent.config import settings
 from agent.logger.interaction_logger import (
     AvatarEventLog,
@@ -71,6 +73,26 @@ def get_memory_writer() -> MemoryWriter:
 
 
 MemoryWriterDep = Annotated[MemoryWriter, Depends(get_memory_writer)]
+
+
+@lru_cache
+def get_analytics_store() -> AnalyticsStore:
+    """Return the process-wide analytics store (created on first use)."""
+    return AnalyticsStore(Path(settings.storage_dir) / "app.sqlite")
+
+
+AnalyticsStoreDep = Annotated[AnalyticsStore, Depends(get_analytics_store)]
+
+
+@lru_cache
+def get_analyzer() -> Analyzer:
+    """Return the configured analyzer (rule by default, ollama when requested)."""
+    if settings.analytics_backend == "ollama":
+        return LLMAnalyzer(settings.ollama_base_url, settings.ollama_model)
+    return RuleAnalyzer()
+
+
+AnalyzerDep = Annotated[Analyzer, Depends(get_analyzer)]
 
 
 class StartSessionRequest(BaseModel):
@@ -156,6 +178,11 @@ class ExplicitWriteRequest(BaseModel):
 class ExtractRequest(BaseModel):
     conversation: str
     turn_id: str | None = None
+
+
+class AnalyzeRequest(BaseModel):
+    user_input: str
+    latency_ms: int | None = None
 
 
 @app.get("/health")
@@ -394,3 +421,27 @@ def extract_and_write(req: ExtractRequest, writer: MemoryWriterDep, logger: Logg
     extractor = LLMExtractor(settings.ollama_base_url, settings.ollama_model)
     ops = extractor.extract(req.conversation)
     return writer.apply(ops, logger=logger if req.turn_id else None, turn_id=req.turn_id)
+
+
+# ── Phase 15: interaction analytics ────────────────────────────────────────────
+
+
+@app.post("/turns/{turn_id}/analyze", status_code=status.HTTP_201_CREATED)
+def analyze_turn(
+    turn_id: str,
+    req: AnalyzeRequest,
+    analyzer: AnalyzerDep,
+    analytics: AnalyticsStoreDep,
+) -> InferredFeedbackLog:
+    analysis = analyzer.analyze(req.user_input, latency_ms=req.latency_ms)
+    return analytics.record(turn_id, analysis)
+
+
+@app.get("/turns/{turn_id}/inferred-feedback")
+def get_inferred_feedback(turn_id: str, analytics: AnalyticsStoreDep) -> list[InferredFeedbackLog]:
+    return analytics.get_for_turn(turn_id)
+
+
+@app.get("/analytics/issue-types")
+def get_issue_type_counts(analytics: AnalyticsStoreDep) -> dict[str, int]:
+    return analytics.issue_type_counts()

--- a/services/agent/src/agent/config.py
+++ b/services/agent/src/agent/config.py
@@ -22,5 +22,8 @@ class Settings(BaseSettings):
     embedding_backend: str = "hash"  # "hash" | "ollama"
     embedding_model: str = "embeddinggemma"
 
+    # Interaction analytics (Phase 15). "rule" = offline/deterministic default.
+    analytics_backend: str = "rule"  # "rule" | "ollama"
+
 
 settings = Settings()

--- a/services/agent/tests/analytics_test.py
+++ b/services/agent/tests/analytics_test.py
@@ -1,0 +1,52 @@
+"""Tests for interaction analytics (Phase 15), using the deterministic RuleAnalyzer."""
+
+from pathlib import Path
+
+from agent.analytics.analyzer import RuleAnalyzer
+from agent.analytics.store import AnalyticsStore
+from agent.logger.interaction_logger import InteractionLogger
+
+
+def test_detects_correction_as_dissatisfaction() -> None:
+    analysis = RuleAnalyzer().analyze("違う、そうじゃなくて")
+    assert analysis.issue_type == "misunderstanding"
+    assert analysis.predicted_satisfaction < 0.6
+    assert analysis.evidence is not None
+
+
+def test_detects_too_abstract_request() -> None:
+    analysis = RuleAnalyzer().analyze("もっと具体的に説明して")
+    assert analysis.issue_type == "too_abstract"
+
+
+def test_positive_feedback_raises_satisfaction() -> None:
+    analysis = RuleAnalyzer().analyze("いいね、助かる")
+    assert analysis.predicted_satisfaction > 0.6
+    assert analysis.issue_type is None
+
+
+def test_high_latency_flagged_when_no_other_signal() -> None:
+    analysis = RuleAnalyzer().analyze("わかった", latency_ms=45_000)
+    assert analysis.issue_type == "latency"
+
+
+def test_neutral_input_has_low_confidence() -> None:
+    analysis = RuleAnalyzer().analyze("今日はいい天気だね")
+    assert analysis.issue_type is None
+    assert analysis.confidence < 0.5
+
+
+def test_record_and_query_inferred_feedback(tmp_path: Path) -> None:
+    db = tmp_path / "app.sqlite"
+    logger = InteractionLogger(db)
+    session = logger.start_session(model="gemma4:31b")
+    turn_id = logger.log_turn(session.id, user_input="違う、それは浅い").id
+
+    analytics = AnalyticsStore(db)
+    analysis = RuleAnalyzer().analyze("違う、それは浅い")
+    analytics.record(turn_id, analysis)
+
+    stored = analytics.get_for_turn(turn_id)
+    assert len(stored) == 1
+    assert stored[0].issue_type == "misunderstanding"
+    assert analytics.issue_type_counts()["misunderstanding"] == 1

--- a/services/agent/tests/api_analytics_test.py
+++ b/services/agent/tests/api_analytics_test.py
@@ -1,0 +1,37 @@
+"""API-level test for the analytics endpoints (Phase 15)."""
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agent.analytics.store import AnalyticsStore
+from agent.app import app, get_analytics_store, get_logger
+from agent.logger.interaction_logger import InteractionLogger
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> Iterator[TestClient]:
+    db = tmp_path / "app.sqlite"
+    # Analytics and the logger must share the DB: inferred_feedback_logs FKs turn_logs.
+    app.dependency_overrides[get_analytics_store] = lambda: AnalyticsStore(db)
+    app.dependency_overrides[get_logger] = lambda: InteractionLogger(db)
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_analyze_and_read_back(client: TestClient) -> None:
+    session_id = client.post("/sessions", json={"model": "gemma4:31b"}).json()["id"]
+    turn_id = client.post(f"/sessions/{session_id}/turns", json={"user_input": "違う、それは浅い"}).json()["id"]
+
+    created = client.post(f"/turns/{turn_id}/analyze", json={"user_input": "違う、それは浅い"})
+    assert created.status_code == 201
+    assert created.json()["issue_type"] == "misunderstanding"
+
+    stored = client.get(f"/turns/{turn_id}/inferred-feedback")
+    assert stored.status_code == 200
+    assert len(stored.json()) == 1
+
+    counts = client.get("/analytics/issue-types")
+    assert counts.json()["misunderstanding"] == 1


### PR DESCRIPTION
各ターンのユーザー発話から満足度・不満を推定し inferred_feedback_logs に保存。Closes #56

## 内容
- `RuleAnalyzer`（既定・決定的）: 否定/訂正/再質問フレーズ + latency を検出 → predicted_satisfaction / issue_type / evidence / confidence
- `LLMAnalyzer`（opt-in, Ollama。失敗時 rule にフォールバック）
- `AnalyticsStore`: record / get_for_turn / issue_type_counts
- API: `/turns/{id}/analyze` · `/turns/{id}/inferred-feedback` · `/analytics/issue-types`

## 検証
ruff / format / pytest **41 passed**（ローカル）。pyproject 固定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)