### PR TITLE
feat: Dashboard v1 (Phase 16)

### DIFF
--- a/services/agent/src/agent/app.py
+++ b/services/agent/src/agent/app.py
@@ -7,11 +7,19 @@ from pathlib import Path
 from typing import Annotated
 
 from fastapi import Depends, FastAPI, HTTPException, Query, status
+from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
 from agent.analytics.analyzer import Analyzer, LLMAnalyzer, RuleAnalyzer
 from agent.analytics.store import AnalyticsStore, InferredFeedbackLog
 from agent.config import settings
+from agent.dashboard import (
+    Dashboard,
+    DashboardStats,
+    DissatisfactionEntry,
+    SessionDetail,
+    SessionOverview,
+)
 from agent.logger.interaction_logger import (
     AvatarEventLog,
     ExplicitFeedbackLog,
@@ -93,6 +101,15 @@ def get_analyzer() -> Analyzer:
 
 
 AnalyzerDep = Annotated[Analyzer, Depends(get_analyzer)]
+
+
+@lru_cache
+def get_dashboard() -> Dashboard:
+    """Return the process-wide dashboard aggregator (created on first use)."""
+    return Dashboard(Path(settings.storage_dir) / "app.sqlite")
+
+
+DashboardDep = Annotated[Dashboard, Depends(get_dashboard)]
 
 
 class StartSessionRequest(BaseModel):
@@ -445,3 +462,111 @@ def get_inferred_feedback(turn_id: str, analytics: AnalyticsStoreDep) -> list[In
 @app.get("/analytics/issue-types")
 def get_issue_type_counts(analytics: AnalyticsStoreDep) -> dict[str, int]:
     return analytics.issue_type_counts()
+
+
+# ── Phase 16: dashboard (read-only aggregation + simple UI) ────────────────────
+
+
+@app.get("/dashboard/sessions")
+def dashboard_sessions(dashboard: DashboardDep) -> list[SessionOverview]:
+    return dashboard.list_sessions()
+
+
+@app.get("/dashboard/sessions/{session_id}")
+def dashboard_session_detail(session_id: str, dashboard: DashboardDep) -> SessionDetail:
+    detail = dashboard.session_detail(session_id)
+    if detail is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="session not found")
+    return detail
+
+
+@app.get("/dashboard/search")
+def dashboard_search(dashboard: DashboardDep, q: str, limit: int = 50) -> list[TurnLog]:
+    return dashboard.search_turns(q, limit=limit)
+
+
+@app.get("/dashboard/dissatisfaction")
+def dashboard_dissatisfaction(dashboard: DashboardDep, limit: int = 50) -> list[DissatisfactionEntry]:
+    return dashboard.dissatisfaction(limit=limit)
+
+
+@app.get("/dashboard/stats")
+def dashboard_stats(dashboard: DashboardDep) -> DashboardStats:
+    return dashboard.stats()
+
+
+@app.get("/dashboard", response_class=HTMLResponse)
+def dashboard_page() -> str:
+    return _DASHBOARD_HTML
+
+
+_DASHBOARD_HTML = """<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>avatar-agent dashboard</title>
+<style>
+  body { font-family: system-ui, sans-serif; margin: 24px; max-width: 920px; color: #222; }
+  h1 { font-size: 20px; } h2 { font-size: 16px; margin-top: 28px; }
+  .stat { display: inline-block; background: #f0f4ff; border-radius: 8px; padding: 8px 12px; margin: 4px; }
+  table { border-collapse: collapse; width: 100%; font-size: 13px; }
+  th, td { border: 1px solid #ddd; padding: 6px 8px; text-align: left; }
+  .bad { color: #c0392b; } input { padding: 6px; } button { padding: 6px 12px; }
+</style>
+</head>
+<body>
+<h1>avatar-agent dashboard</h1>
+<div id="stats"></div>
+
+<h2>セッション</h2>
+<table id="sessions"><thead><tr>
+  <th>started</th><th>model</th><th>turns</th><th>avg latency(ms)</th><th>avg satisfaction</th>
+</tr></thead><tbody></tbody></table>
+
+<h2>不満ログ</h2>
+<table id="dissat"><thead><tr>
+  <th>issue</th><th>satisfaction</th><th>user_input</th><th>evidence</th>
+</tr></thead><tbody></tbody></table>
+
+<h2>会話検索</h2>
+<input id="q" placeholder="キーワード"><button id="searchBtn">検索</button>
+<table id="results"><thead><tr><th>timestamp</th><th>user</th><th>assistant</th></tr></thead><tbody></tbody></table>
+
+<script>
+const fmt = (v) => (v == null ? "-" : (typeof v === "number" ? v.toFixed(2) : v));
+async function getJSON(url) { const r = await fetch(url); return r.ok ? r.json() : null; }
+function rows(tableId, items, cols) {
+  const tb = document.querySelector(`#${tableId} tbody`);
+  tb.innerHTML = "";
+  for (const it of items) {
+    const tr = document.createElement("tr");
+    for (const c of cols) { const td = document.createElement("td"); td.textContent = fmt(it[c]); tr.appendChild(td); }
+    tb.appendChild(tr);
+  }
+}
+async function load() {
+  const s = await getJSON("/dashboard/stats");
+  if (s) {
+    document.getElementById("stats").innerHTML =
+      [["sessions", s.session_count], ["turns", s.turn_count],
+       ["avg latency(ms)", fmt(s.avg_latency_ms)], ["avg satisfaction", fmt(s.avg_satisfaction)],
+       ["tool success", fmt(s.tool_success_rate)], ["memory accesses", s.memory_access_count]]
+      .map(([k, v]) => `<span class="stat">${k}: <b>${v}</b></span>`).join("") +
+      "<div>issue types: " + JSON.stringify(s.issue_type_counts) + "</div>";
+  }
+  rows("sessions", (await getJSON("/dashboard/sessions")) || [],
+       ["started_at", "model", "turn_count", "avg_latency_ms", "avg_satisfaction"]);
+  rows("dissat", (await getJSON("/dashboard/dissatisfaction")) || [],
+       ["issue_type", "predicted_satisfaction", "user_input", "evidence"]);
+}
+document.getElementById("searchBtn").addEventListener("click", async () => {
+  const q = document.getElementById("q").value.trim();
+  if (!q) return;
+  rows("results", (await getJSON("/dashboard/search?q=" + encodeURIComponent(q))) || [],
+       ["timestamp", "user_input", "assistant_output"]);
+});
+load();
+</script>
+</body>
+</html>
+"""

--- a/services/agent/src/agent/dashboard.py
+++ b/services/agent/src/agent/dashboard.py
@@ -1,0 +1,190 @@
+"""Dashboard aggregation (Phase 16).
+
+Read-only views over all logged data: session overviews, per-turn detail
+(feedback / analytics / tool calls / memory accesses), full-text search across
+turns, a dissatisfaction list, and overall stats. Pure SQLite aggregation.
+"""
+
+from __future__ import annotations
+
+from contextlib import closing
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+from agent.analytics.store import AnalyticsStore, InferredFeedbackLog
+from agent.logger.db import connect
+from agent.logger.interaction_logger import (
+    ExplicitFeedbackLog,
+    InteractionLogger,
+    MemoryAccessLog,
+    Session,
+    ToolCallLog,
+    TurnLog,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_DISSATISFACTION_THRESHOLD = 0.5
+_DEFAULT_SEARCH_LIMIT = 50
+_DEFAULT_DISSATISFACTION_LIMIT = 50
+
+_SESSION_OVERVIEWS = """
+SELECT
+  s.id, s.title, s.started_at, s.ended_at, s.model,
+  COUNT(t.id) AS turn_count,
+  AVG(t.latency_ms) AS avg_latency_ms,
+  (SELECT AVG(i.predicted_satisfaction)
+     FROM inferred_feedback_logs i
+     JOIN turn_logs t2 ON i.turn_id = t2.id
+    WHERE t2.session_id = s.id) AS avg_satisfaction
+FROM sessions s
+LEFT JOIN turn_logs t ON t.session_id = s.id
+GROUP BY s.id
+ORDER BY s.started_at DESC
+"""
+
+_SEARCH_TURNS = """
+SELECT * FROM turn_logs
+WHERE user_input LIKE ? OR assistant_output LIKE ?
+ORDER BY timestamp DESC
+LIMIT ?
+"""
+
+_DISSATISFACTION = """
+SELECT t.id AS turn_id, t.session_id, t.user_input,
+       i.predicted_satisfaction, i.issue_type, i.evidence
+FROM turn_logs t
+JOIN inferred_feedback_logs i ON i.turn_id = t.id
+WHERE i.issue_type IS NOT NULL OR i.predicted_satisfaction < ?
+ORDER BY i.created_at DESC
+LIMIT ?
+"""
+
+
+class SessionOverview(BaseModel):
+    """One row of the session list with rollup stats."""
+
+    id: str
+    title: str | None = None
+    started_at: str
+    ended_at: str | None = None
+    model: str | None = None
+    turn_count: int
+    avg_latency_ms: float | None = None
+    avg_satisfaction: float | None = None
+
+
+class TurnDetail(BaseModel):
+    """A turn with everything logged about it."""
+
+    turn: TurnLog
+    explicit_feedback: list[ExplicitFeedbackLog]
+    inferred_feedback: list[InferredFeedbackLog]
+    tool_calls: list[ToolCallLog]
+    memory_accesses: list[MemoryAccessLog]
+
+
+class SessionDetail(BaseModel):
+    """A session and its fully-detailed turns."""
+
+    session: Session
+    turns: list[TurnDetail]
+
+
+class DissatisfactionEntry(BaseModel):
+    """A turn flagged as a likely dissatisfaction point."""
+
+    turn_id: str
+    session_id: str | None = None
+    user_input: str | None = None
+    predicted_satisfaction: float | None = None
+    issue_type: str | None = None
+    evidence: str | None = None
+
+
+class DashboardStats(BaseModel):
+    """Overall rollup across all sessions."""
+
+    session_count: int
+    turn_count: int
+    avg_latency_ms: float | None = None
+    avg_satisfaction: float | None = None
+    issue_type_counts: dict[str, int]
+    rating_counts: dict[str, int]
+    tool_call_count: int
+    tool_success_rate: float | None = None
+    memory_access_count: int
+
+
+class Dashboard:
+    """Aggregated, read-only views over the logged data."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        # Ensure all referenced tables exist even if nothing has been logged yet.
+        self._logger = InteractionLogger(db_path)
+        self._analytics = AnalyticsStore(db_path)
+
+    def list_sessions(self) -> list[SessionOverview]:
+        with closing(connect(self._db_path)) as conn:
+            rows = conn.execute(_SESSION_OVERVIEWS).fetchall()
+        return [SessionOverview(**dict(row)) for row in rows]
+
+    def session_detail(self, session_id: str) -> SessionDetail | None:
+        session = self._logger.get_session(session_id)
+        if session is None:
+            return None
+        turns = [
+            TurnDetail(
+                turn=turn,
+                explicit_feedback=self._logger.get_feedback(turn.id),
+                inferred_feedback=self._analytics.get_for_turn(turn.id),
+                tool_calls=self._logger.get_tool_calls(turn.id),
+                memory_accesses=self._logger.get_memory_accesses(turn.id),
+            )
+            for turn in self._logger.get_turns(session_id)
+        ]
+        return SessionDetail(session=session, turns=turns)
+
+    def search_turns(self, query: str, *, limit: int = _DEFAULT_SEARCH_LIMIT) -> list[TurnLog]:
+        like = f"%{query}%"
+        with closing(connect(self._db_path)) as conn:
+            rows = conn.execute(_SEARCH_TURNS, (like, like, limit)).fetchall()
+        return [TurnLog(**dict(row)) for row in rows]
+
+    def dissatisfaction(self, *, limit: int = _DEFAULT_DISSATISFACTION_LIMIT) -> list[DissatisfactionEntry]:
+        with closing(connect(self._db_path)) as conn:
+            rows = conn.execute(_DISSATISFACTION, (_DISSATISFACTION_THRESHOLD, limit)).fetchall()
+        return [DissatisfactionEntry(**dict(row)) for row in rows]
+
+    def stats(self) -> DashboardStats:
+        with closing(connect(self._db_path)) as conn:
+            session_count = conn.execute("SELECT COUNT(*) AS n FROM sessions").fetchone()["n"]
+            turn_row = conn.execute(
+                "SELECT COUNT(*) AS n, AVG(latency_ms) AS lat FROM turn_logs",
+            ).fetchone()
+            avg_sat = conn.execute(
+                "SELECT AVG(predicted_satisfaction) AS s FROM inferred_feedback_logs",
+            ).fetchone()["s"]
+            rating_rows = conn.execute(
+                "SELECT rating, COUNT(*) AS n FROM explicit_feedback_logs WHERE rating IS NOT NULL GROUP BY rating",
+            ).fetchall()
+            tool_row = conn.execute(
+                "SELECT COUNT(*) AS total, SUM(CASE WHEN status = 'ok' THEN 1 ELSE 0 END) AS ok FROM tool_call_logs",
+            ).fetchone()
+            mem_count = conn.execute("SELECT COUNT(*) AS n FROM memory_access_logs").fetchone()["n"]
+
+        total_tools = tool_row["total"]
+        return DashboardStats(
+            session_count=session_count,
+            turn_count=turn_row["n"],
+            avg_latency_ms=turn_row["lat"],
+            avg_satisfaction=avg_sat,
+            issue_type_counts=self._analytics.issue_type_counts(),
+            rating_counts={str(row["rating"]): row["n"] for row in rating_rows},
+            tool_call_count=total_tools,
+            tool_success_rate=(tool_row["ok"] / total_tools) if total_tools else None,
+            memory_access_count=mem_count,
+        )

--- a/services/agent/tests/dashboard_test.py
+++ b/services/agent/tests/dashboard_test.py
@@ -1,0 +1,83 @@
+"""Tests for dashboard aggregation (Phase 16)."""
+
+from pathlib import Path
+
+from agent.analytics.analyzer import RuleAnalyzer
+from agent.analytics.store import AnalyticsStore
+from agent.dashboard import Dashboard
+from agent.logger.interaction_logger import InteractionLogger
+
+
+def _seed(db: Path) -> tuple[str, str, str]:
+    logger = InteractionLogger(db)
+    session = logger.start_session(model="gemma4:31b", title="test")
+    t1 = logger.log_turn(session.id, user_input="知識編集を研究したい", assistant_output="いいね", latency_ms=1000)
+    t2 = logger.log_turn(session.id, user_input="違う、それは浅い", assistant_output="ごめん", latency_ms=2000)
+
+    logger.log_tool_call(t1.id, "filesystem.read", status="ok")
+    logger.log_tool_call(t1.id, "web.search", status="error")
+    logger.log_memory_access(t1.id, "read", memory_id="m1")
+    logger.log_explicit_feedback(t1.id, rating=5, label="helpful")
+
+    AnalyticsStore(db).record(t2.id, RuleAnalyzer().analyze("違う、それは浅い"))
+    return session.id, t1.id, t2.id
+
+
+def test_list_sessions_rollup(tmp_path: Path) -> None:
+    db = tmp_path / "app.sqlite"
+    _seed(db)
+    overviews = Dashboard(db).list_sessions()
+    assert len(overviews) == 1
+    assert overviews[0].turn_count == 2
+    assert overviews[0].avg_latency_ms == 1500
+
+
+def test_session_detail_includes_all_logs(tmp_path: Path) -> None:
+    db = tmp_path / "app.sqlite"
+    session_id, t1, _t2 = _seed(db)
+    detail = Dashboard(db).session_detail(session_id)
+    assert detail is not None
+    assert len(detail.turns) == 2
+
+    turn1 = next(td for td in detail.turns if td.turn.id == t1)
+    assert len(turn1.tool_calls) == 2
+    assert len(turn1.memory_accesses) == 1  # 使われた記憶が見える
+    assert len(turn1.explicit_feedback) == 1
+
+
+def test_search_finds_turn(tmp_path: Path) -> None:
+    db = tmp_path / "app.sqlite"
+    _seed(db)
+    hits = Dashboard(db).search_turns("研究")
+    assert len(hits) == 1
+    assert "研究" in hits[0].user_input
+
+
+def test_dissatisfaction_list(tmp_path: Path) -> None:
+    db = tmp_path / "app.sqlite"
+    _session, _t1, t2 = _seed(db)
+    flagged = Dashboard(db).dissatisfaction()
+    assert len(flagged) == 1
+    assert flagged[0].turn_id == t2
+    assert flagged[0].issue_type == "misunderstanding"
+
+
+def test_stats_rollup(tmp_path: Path) -> None:
+    db = tmp_path / "app.sqlite"
+    _seed(db)
+    stats = Dashboard(db).stats()
+    assert stats.session_count == 1
+    assert stats.turn_count == 2
+    assert stats.tool_call_count == 2
+    assert stats.tool_success_rate == 0.5
+    assert stats.memory_access_count == 1
+    assert stats.rating_counts == {"5": 1}
+    assert stats.issue_type_counts == {"misunderstanding": 1}
+
+
+def test_empty_dashboard(tmp_path: Path) -> None:
+    db = tmp_path / "app.sqlite"
+    dashboard = Dashboard(db)
+    assert dashboard.list_sessions() == []
+    assert dashboard.stats().turn_count == 0
+    assert dashboard.session_detail("missing") is None


### PR DESCRIPTION
全ログ/データの読み取り・集計層 + ブラウザで開ける簡易 UI。MVP コア最後のフェーズ。Closes #57

## 内容
- `Dashboard`（SQLite 集計）: list_sessions / session_detail（feedback・inferred・tool・memory access）/ search_turns / dissatisfaction / stats
- API: `/dashboard/sessions` · `/sessions/{id}` · `/search` · `/dissatisfaction` · `/stats`
- `GET /dashboard`: ブラウザで開ける簡易 HTML（Electron 不要 / `pnpm dev:all` 後 http://127.0.0.1:8000/dashboard）

## 検証
ruff / format / pytest **47 passed**（ローカル）。pyproject 固定。

> マージ後、MVP コア（Phase 8–16）が main に完成。

🤖 Generated with [Claude Code](https://claude.com/claude-code)