### PR TITLE
fix: ローカル dev 環境の修正（pnpm allowBuilds / agent ポート / storage ignore）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ BRIDGE_HOST=127.0.0.1
 
 # ─── Python agent service (FastAPI: logging / feedback / analytics) ────────────
 # `pnpm dev:agent` で起動。停止していても会話は動く（ログ・フィードバックは best-effort）
-AGENT_SERVICE_URL=http://127.0.0.1:8000
+AGENT_SERVICE_URL=http://127.0.0.1:8123
 
 # ─── OpenClaw Gateway (Phase 3) ───────────────────────────────────────────────
 # Uncomment and fill when setting up OpenClaw integration

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ __pycache__/
 *.sqlite
 *.sqlite-journal
 *.sqlite-wal
+
+# Runtime storage dirs created when dev processes run from subdirectories
+apps/*/storage/
+services/*/storage/

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Desktop companion with sprite avatar, Ollama LLM, and OpenClaw desktop automation",
   "scripts": {
     "dev": "concurrently --names \"bridge,ui\" --prefix-colors \"cyan,magenta\" --kill-others-on-fail \"pnpm --filter bridge dev\" \"pnpm --filter ui dev\"",
-    "dev:agent": "uv run --directory services/agent uvicorn agent.app:app --port 8000",
+    "dev:agent": "uv run --directory services/agent uvicorn agent.app:app --port 8123",
     "dev:all": "concurrently --names \"agent,bridge,ui\" --prefix-colors \"green,cyan,magenta\" \"pnpm dev:agent\" \"pnpm --filter bridge dev\" \"pnpm --filter ui dev\"",
     "build": "pnpm -r build",
     "test": "pnpm -r test",

--- a/packages/utils/src/config.ts
+++ b/packages/utils/src/config.ts
@@ -35,7 +35,7 @@ export const config = {
   },
   // Python agent service (FastAPI): interaction logging / feedback / analytics
   agentService: {
-    baseUrl: env("AGENT_SERVICE_URL", "http://127.0.0.1:8000"),
+    baseUrl: env("AGENT_SERVICE_URL", "http://127.0.0.1:8123"),
   },
   bridge: {
     port: envInt("BRIDGE_PORT", 3000),

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,11 @@
 packages:
   - 'apps/*'
   - 'packages/*'
+
+# Allow these deps to run install/build scripts (electron downloads its binary,
+# esbuild its own).
+# - pnpm 10+ (local): reads `allowBuilds` from here.
+# - pnpm 9 (CI): reads the same list from package.json's "pnpm.onlyBuiltDependencies".
+allowBuilds:
+  electron: true
+  esbuild: true


### PR DESCRIPTION
`pnpm dev:all` がローカルで起動するための環境修正。

## 内容
1. **pnpm-workspace.yaml `allowBuilds`** — pnpm 10+ は package.json の `pnpm.onlyBuiltDependencies` を読まないため electron/esbuild の postinstall が ignore される。`allowBuilds: {electron: true, esbuild: true}` を追加（CI の pnpm 9 は引き続き package.json を読むので両対応）。
2. **agent ポート 8000 → 8123** — 8000 がローカルの別用途と衝突するため変更（package.json dev:agent / config.ts AGENT_SERVICE_URL / .env.example）。
3. **gitignore** — dev 実行時に subdir に作られる `apps/*/storage/` `services/*/storage/` を無視。

## 検証
- `pnpm install` → exit 0（electron/esbuild ビルド済み）
- agent を :8123 で起動 → `/dashboard` `/health` 200
- `require("electron")` が apps/ui から解決

🤖 Generated with [Claude Code](https://claude.com/claude-code)