### PR TITLE
feat: Tool Use v1 (Phase 17)

### DIFF
--- a/services/agent/src/agent/app.py
+++ b/services/agent/src/agent/app.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from functools import lru_cache
 from pathlib import Path
 from typing import Annotated
@@ -34,6 +35,8 @@ from agent.memory.profile import ProfileStore
 from agent.memory.retrieval import MemoryRetriever, ScoredMemory, build_context
 from agent.memory.store import Memory, MemoryStore, MemoryType, Task, TaskStatus
 from agent.memory.writer import LLMExtractor, MemoryWriter
+from agent.tools.base import ToolResult, ToolSpec  # noqa: TC001  (FastAPI resolves these at runtime)
+from agent.tools.registry import ToolRegistry, build_default_registry
 
 app = FastAPI(title="avatar-agent", version="0.1.0")
 
@@ -110,6 +113,15 @@ def get_dashboard() -> Dashboard:
 
 
 DashboardDep = Annotated[Dashboard, Depends(get_dashboard)]
+
+
+@lru_cache
+def get_tool_registry() -> ToolRegistry:
+    """Return the process-wide tool registry (created on first use)."""
+    return build_default_registry(Path(settings.tools_root), get_memory_store())
+
+
+ToolRegistryDep = Annotated[ToolRegistry, Depends(get_tool_registry)]
 
 
 class StartSessionRequest(BaseModel):
@@ -200,6 +212,11 @@ class ExtractRequest(BaseModel):
 class AnalyzeRequest(BaseModel):
     user_input: str
     latency_ms: int | None = None
+
+
+class ToolInvokeRequest(BaseModel):
+    args: dict[str, object] = {}
+    turn_id: str | None = None
 
 
 @app.get("/health")
@@ -493,6 +510,36 @@ def dashboard_dissatisfaction(dashboard: DashboardDep, limit: int = 50) -> list[
 @app.get("/dashboard/stats")
 def dashboard_stats(dashboard: DashboardDep) -> DashboardStats:
     return dashboard.stats()
+
+
+# ── Phase 17: tool use (read-only filesystem + memory) ─────────────────────────
+
+
+@app.get("/tools")
+def list_tools(registry: ToolRegistryDep) -> list[ToolSpec]:
+    return registry.specs()
+
+
+@app.post("/tools/{name}")
+def invoke_tool(
+    name: str,
+    req: ToolInvokeRequest,
+    registry: ToolRegistryDep,
+    logger: LoggerDep,
+) -> ToolResult:
+    result = registry.run(name, req.args)
+    if req.turn_id:
+        logger.log_tool_call(
+            req.turn_id,
+            name,
+            input_json=json.dumps(req.args, ensure_ascii=False),
+            output_json=(
+                json.dumps(result.output, ensure_ascii=False, default=str) if result.output is not None else None
+            ),
+            status="ok" if result.ok else "error",
+            error=result.error,
+        )
+    return result
 
 
 @app.get("/dashboard", response_class=HTMLResponse)

--- a/services/agent/src/agent/config.py
+++ b/services/agent/src/agent/config.py
@@ -17,6 +17,8 @@ class Settings(BaseSettings):
     ollama_model: str = "gemma4:31b"
     ollama_timeout_ms: int = 120_000
     storage_dir: str = "./storage"
+    # Root directory that filesystem tools (Phase 17) may list/read within.
+    tools_root: str = "."
 
     # Memory retrieval embeddings (Phase 13). "hash" = offline/deterministic default.
     embedding_backend: str = "hash"  # "hash" | "ollama"

--- a/services/agent/src/agent/tools/base.py
+++ b/services/agent/src/agent/tools/base.py
@@ -1,0 +1,25 @@
+"""Shared tool types (Phase 17)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ToolError(Exception):
+    """Raised when a tool refuses or fails to run (validation, safety, IO)."""
+
+
+class ToolSpec(BaseModel):
+    """Public description of a tool for listing / LLM tool selection."""
+
+    name: str
+    description: str
+    args_schema: dict[str, object]
+
+
+class ToolResult(BaseModel):
+    """Outcome of a tool invocation."""
+
+    ok: bool
+    output: object | None = None
+    error: str | None = None

--- a/services/agent/src/agent/tools/filesystem.py
+++ b/services/agent/src/agent/tools/filesystem.py
@@ -1,0 +1,69 @@
+"""Safe, read-only filesystem tools (Phase 17).
+
+Only list/read within an allowed root. No write/delete/exec. Path traversal
+outside the root and access to credential-ish files are denied.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent.tools.base import ToolError
+
+# Substrings that mark a path as sensitive — reading/listing these is refused.
+_DENY_SUBSTRINGS = (
+    ".env",
+    ".key",
+    ".pem",
+    ".pfx",
+    ".p12",
+    "id_rsa",
+    "id_ed25519",
+    ".ssh",
+    "credential",
+    ".secret",
+    ".npmrc",
+    ".git/",
+    ".aws",
+)
+_MAX_READ_BYTES = 1_000_000
+
+
+class FilesystemTools:
+    """Read-only filesystem access scoped to a root directory."""
+
+    def __init__(self, root: Path) -> None:
+        self._root = Path(root).resolve()
+
+    def _resolve(self, rel_path: str) -> Path:
+        target = (self._root / rel_path).resolve()
+        if target != self._root and self._root not in target.parents:
+            raise ToolError("path escapes the allowed root")
+        if any(token in str(target).lower() for token in _DENY_SUBSTRINGS):
+            raise ToolError("access to a sensitive path is denied")
+        return target
+
+    def list_dir(self, path: str = ".") -> list[dict[str, object]]:
+        target = self._resolve(path)
+        if not target.is_dir():
+            raise ToolError("not a directory")
+        entries: list[dict[str, object]] = []
+        for entry in sorted(target.iterdir(), key=lambda p: p.name):
+            is_file = entry.is_file()
+            entries.append(
+                {
+                    "name": entry.name,
+                    "type": "file" if is_file else "dir",
+                    "size": entry.stat().st_size if is_file else None,
+                },
+            )
+        return entries
+
+    def read_file(self, path: str) -> dict[str, object]:
+        target = self._resolve(path)
+        if not target.is_file():
+            raise ToolError("not a file")
+        size = target.stat().st_size
+        if size > _MAX_READ_BYTES:
+            raise ToolError(f"file too large ({size} bytes, limit {_MAX_READ_BYTES})")
+        return {"path": path, "content": target.read_text(encoding="utf-8", errors="replace")}

--- a/services/agent/src/agent/tools/memory_tools.py
+++ b/services/agent/src/agent/tools/memory_tools.py
@@ -1,0 +1,35 @@
+"""Memory tools: search / write over the long-term memory store (Phase 17)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from agent.memory.store import MemoryStore, MemoryType
+
+_DEFAULT_SEARCH_LIMIT = 10
+_DEFAULT_IMPORTANCE = 3
+
+
+class MemoryTools:
+    """Thin tool wrapper over MemoryStore (returns JSON-able dicts)."""
+
+    def __init__(self, store: MemoryStore) -> None:
+        self._store = store
+
+    def search(
+        self,
+        query: str,
+        memory_type: MemoryType | None = None,
+        limit: int = _DEFAULT_SEARCH_LIMIT,
+    ) -> list[dict[str, object]]:
+        memories = self._store.search_memories(query, memory_type=memory_type, limit=limit)
+        return [m.model_dump() for m in memories]
+
+    def write(
+        self,
+        content: str,
+        memory_type: MemoryType = "semantic",
+        importance: int = _DEFAULT_IMPORTANCE,
+    ) -> dict[str, object]:
+        return self._store.add_memory(memory_type, content, source="tool", importance=importance).model_dump()

--- a/services/agent/src/agent/tools/registry.py
+++ b/services/agent/src/agent/tools/registry.py
@@ -1,0 +1,126 @@
+"""Tool registry: schema listing, arg validation, safe dispatch (Phase 17)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ValidationError
+
+from agent.memory.store import MemoryType  # noqa: TC001  (pydantic field type, resolved at runtime)
+from agent.tools.base import ToolError, ToolResult, ToolSpec
+from agent.tools.filesystem import FilesystemTools
+from agent.tools.memory_tools import MemoryTools
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from agent.memory.store import MemoryStore
+
+_DEFAULT_SEARCH_LIMIT = 10
+_DEFAULT_IMPORTANCE = 3
+
+
+class FilesystemListArgs(BaseModel):
+    path: str = "."
+
+
+class FilesystemReadArgs(BaseModel):
+    path: str
+
+
+class MemorySearchArgs(BaseModel):
+    query: str
+    memory_type: MemoryType | None = None
+    limit: int = _DEFAULT_SEARCH_LIMIT
+
+
+class MemoryWriteArgs(BaseModel):
+    content: str
+    memory_type: MemoryType = "semantic"
+    importance: int = _DEFAULT_IMPORTANCE
+
+
+class _RegisteredTool:
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        args_model: type[BaseModel],
+        handler: Callable[[BaseModel], object],
+    ) -> None:
+        self.name = name
+        self.description = description
+        self.args_model = args_model
+        self.handler = handler
+
+
+class ToolRegistry:
+    """Holds named tools and runs them with validation + error isolation."""
+
+    def __init__(self) -> None:
+        self._tools: dict[str, _RegisteredTool] = {}
+
+    def register(
+        self,
+        name: str,
+        description: str,
+        args_model: type[BaseModel],
+        handler: Callable[[BaseModel], object],
+    ) -> None:
+        self._tools[name] = _RegisteredTool(name, description, args_model, handler)
+
+    def specs(self) -> list[ToolSpec]:
+        return [
+            ToolSpec(name=t.name, description=t.description, args_schema=t.args_model.model_json_schema())
+            for t in self._tools.values()
+        ]
+
+    def names(self) -> list[str]:
+        return list(self._tools)
+
+    def run(self, name: str, raw_args: dict[str, object]) -> ToolResult:
+        tool = self._tools.get(name)
+        if tool is None:
+            return ToolResult(ok=False, error=f"unknown tool: {name}")
+        try:
+            args = tool.args_model.model_validate(raw_args)
+        except ValidationError as exc:
+            return ToolResult(ok=False, error=f"invalid args: {exc.errors()}")
+        try:
+            output = tool.handler(args)
+        except (ToolError, OSError) as exc:
+            return ToolResult(ok=False, error=str(exc))
+        return ToolResult(ok=True, output=output)
+
+
+def build_default_registry(fs_root: Path, store: MemoryStore) -> ToolRegistry:
+    """Register the Phase 17 toolset: read-only filesystem + memory search/write."""
+    fs = FilesystemTools(fs_root)
+    mem = MemoryTools(store)
+    registry = ToolRegistry()
+    registry.register(
+        "filesystem.list",
+        "指定パス(許可ルート内)のファイルとディレクトリ一覧を返す",
+        FilesystemListArgs,
+        lambda a: fs.list_dir(a.path),
+    )
+    registry.register(
+        "filesystem.read",
+        "指定ファイル(許可ルート内、機微ファイルは除外)の内容を返す",
+        FilesystemReadArgs,
+        lambda a: fs.read_file(a.path),
+    )
+    registry.register(
+        "memory.search",
+        "長期記憶をキーワード検索する",
+        MemorySearchArgs,
+        lambda a: mem.search(a.query, a.memory_type, a.limit),
+    )
+    registry.register(
+        "memory.write",
+        "長期記憶に新しい項目を保存する",
+        MemoryWriteArgs,
+        lambda a: mem.write(a.content, a.memory_type, a.importance),
+    )
+    return registry

--- a/services/agent/tests/tools_test.py
+++ b/services/agent/tests/tools_test.py
@@ -1,0 +1,73 @@
+"""Tests for the tool framework (Phase 17)."""
+
+from pathlib import Path
+
+import pytest
+
+from agent.memory.store import MemoryStore
+from agent.tools.base import ToolError
+from agent.tools.filesystem import FilesystemTools
+from agent.tools.registry import build_default_registry
+
+
+def _workspace(tmp_path: Path) -> Path:
+    (tmp_path / "README.md").write_text("# Hello\n本文です\n", encoding="utf-8")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "note.txt").write_text("メモ", encoding="utf-8")
+    (tmp_path / ".env").write_text("SECRET=xyz", encoding="utf-8")
+    return tmp_path
+
+
+def test_filesystem_list_and_read(tmp_path: Path) -> None:
+    fs = FilesystemTools(_workspace(tmp_path))
+    names = {e["name"] for e in fs.list_dir(".")}
+    assert "README.md" in names
+    assert fs.read_file("README.md")["content"].startswith("# Hello")
+
+
+def test_filesystem_denies_sensitive_file(tmp_path: Path) -> None:
+    fs = FilesystemTools(_workspace(tmp_path))
+    with pytest.raises(ToolError, match="sensitive"):
+        fs.read_file(".env")
+
+
+def test_filesystem_denies_path_traversal(tmp_path: Path) -> None:
+    fs = FilesystemTools(_workspace(tmp_path))
+    with pytest.raises(ToolError, match="escapes"):
+        fs.read_file("../outside.txt")
+
+
+def test_registry_runs_filesystem_read(tmp_path: Path) -> None:
+    registry = build_default_registry(_workspace(tmp_path), MemoryStore(tmp_path / "app.sqlite"))
+    result = registry.run("filesystem.read", {"path": "README.md"})
+    assert result.ok
+    assert "Hello" in result.output["content"]
+
+
+def test_registry_memory_write_then_search(tmp_path: Path) -> None:
+    registry = build_default_registry(tmp_path, MemoryStore(tmp_path / "app.sqlite"))
+    write = registry.run("memory.write", {"content": "知識編集を研究している", "importance": 5})
+    assert write.ok
+    found = registry.run("memory.search", {"query": "研究"})
+    assert found.ok
+    assert len(found.output) == 1
+
+
+def test_registry_unknown_tool(tmp_path: Path) -> None:
+    registry = build_default_registry(tmp_path, MemoryStore(tmp_path / "app.sqlite"))
+    result = registry.run("filesystem.delete", {"path": "x"})
+    assert not result.ok
+    assert "unknown tool" in result.error
+
+
+def test_registry_invalid_args(tmp_path: Path) -> None:
+    registry = build_default_registry(tmp_path, MemoryStore(tmp_path / "app.sqlite"))
+    result = registry.run("memory.write", {})  # missing required "content"
+    assert not result.ok
+    assert "invalid args" in result.error
+
+
+def test_specs_list_all_tools(tmp_path: Path) -> None:
+    registry = build_default_registry(tmp_path, MemoryStore(tmp_path / "app.sqlite"))
+    names = {s.name for s in registry.specs()}
+    assert names == {"filesystem.list", "filesystem.read", "memory.search", "memory.write"}


### PR DESCRIPTION
安全な read-only filesystem / memory ツール基盤。Closes #58

## 内容
- `tools/filesystem.py`: 許可ルート内のみ、パストラバーサル拒否、機微ファイル(.env/.key/.ssh 等)拒否、サイズ上限。list_dir / read_file（削除・書込・exec なし）
- `tools/memory_tools.py`: memory.search / write
- `tools/registry.py`: ToolRegistry（schema 公開 + pydantic 引数検証 + エラー隔離）+ build_default_registry
- `app.py`: GET /tools, POST /tools/{name}（tool_call_logs 記録）

## 検証
ruff / format / pytest **55 passed**（ローカル）。pyproject 固定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)