### PR TITLE
feat: Web / Browser Tool (Phase 18)

### DIFF
--- a/services/agent/src/agent/app.py
+++ b/services/agent/src/agent/app.py
@@ -37,6 +37,7 @@ from agent.memory.store import Memory, MemoryStore, MemoryType, Task, TaskStatus
 from agent.memory.writer import LLMExtractor, MemoryWriter
 from agent.tools.base import ToolResult, ToolSpec  # noqa: TC001  (FastAPI resolves these at runtime)
 from agent.tools.registry import ToolRegistry, build_default_registry
+from agent.tools.web import HttpWebClient, StubWebClient, WebClient, WebSource, WebSourceStore
 
 app = FastAPI(title="avatar-agent", version="0.1.0")
 
@@ -116,9 +117,27 @@ DashboardDep = Annotated[Dashboard, Depends(get_dashboard)]
 
 
 @lru_cache
+def get_web_sources() -> WebSourceStore:
+    """Return the process-wide web source store (created on first use)."""
+    return WebSourceStore(Path(settings.storage_dir) / "app.sqlite")
+
+
+WebSourcesDep = Annotated[WebSourceStore, Depends(get_web_sources)]
+
+
+def _build_web_client() -> WebClient:
+    return StubWebClient() if settings.web_backend == "stub" else HttpWebClient()
+
+
+@lru_cache
 def get_tool_registry() -> ToolRegistry:
     """Return the process-wide tool registry (created on first use)."""
-    return build_default_registry(Path(settings.tools_root), get_memory_store())
+    return build_default_registry(
+        Path(settings.tools_root),
+        get_memory_store(),
+        _build_web_client(),
+        get_web_sources(),
+    )
 
 
 ToolRegistryDep = Annotated[ToolRegistry, Depends(get_tool_registry)]
@@ -217,6 +236,7 @@ class AnalyzeRequest(BaseModel):
 class ToolInvokeRequest(BaseModel):
     args: dict[str, object] = {}
     turn_id: str | None = None
+    confirm: bool = False
 
 
 @app.get("/health")
@@ -527,7 +547,7 @@ def invoke_tool(
     registry: ToolRegistryDep,
     logger: LoggerDep,
 ) -> ToolResult:
-    result = registry.run(name, req.args)
+    result = registry.run(name, req.args, confirm=req.confirm)
     if req.turn_id:
         logger.log_tool_call(
             req.turn_id,
@@ -540,6 +560,11 @@ def invoke_tool(
             error=result.error,
         )
     return result
+
+
+@app.get("/web/sources")
+def list_web_sources(sources: WebSourcesDep, limit: int = 50) -> list[WebSource]:
+    return sources.list_sources(limit=limit)
 
 
 @app.get("/dashboard", response_class=HTMLResponse)

--- a/services/agent/src/agent/config.py
+++ b/services/agent/src/agent/config.py
@@ -27,5 +27,8 @@ class Settings(BaseSettings):
     # Interaction analytics (Phase 15). "rule" = offline/deterministic default.
     analytics_backend: str = "rule"  # "rule" | "ollama"
 
+    # Web tools (Phase 18). "http" = real fetch/search, "stub" = offline.
+    web_backend: str = "http"  # "http" | "stub"
+
 
 settings = Settings()

--- a/services/agent/src/agent/tools/base.py
+++ b/services/agent/src/agent/tools/base.py
@@ -15,6 +15,7 @@ class ToolSpec(BaseModel):
     name: str
     description: str
     args_schema: dict[str, object]
+    requires_confirmation: bool = False
 
 
 class ToolResult(BaseModel):

--- a/services/agent/src/agent/tools/registry.py
+++ b/services/agent/src/agent/tools/registry.py
@@ -1,4 +1,4 @@
-"""Tool registry: schema listing, arg validation, safe dispatch (Phase 17)."""
+"""Tool registry: schema listing, arg validation, safe dispatch (Phase 17-18)."""
 
 from __future__ import annotations
 
@@ -10,15 +10,18 @@ from agent.memory.store import MemoryType  # noqa: TC001  (pydantic field type, 
 from agent.tools.base import ToolError, ToolResult, ToolSpec
 from agent.tools.filesystem import FilesystemTools
 from agent.tools.memory_tools import MemoryTools
+from agent.tools.web import WebTools
 
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
     from agent.memory.store import MemoryStore
+    from agent.tools.web import WebClient, WebSourceStore
 
 _DEFAULT_SEARCH_LIMIT = 10
 _DEFAULT_IMPORTANCE = 3
+_DEFAULT_WEB_SEARCH_LIMIT = 5
 
 
 class FilesystemListArgs(BaseModel):
@@ -41,6 +44,16 @@ class MemoryWriteArgs(BaseModel):
     importance: int = _DEFAULT_IMPORTANCE
 
 
+class WebSearchArgs(BaseModel):
+    query: str
+    limit: int = _DEFAULT_WEB_SEARCH_LIMIT
+
+
+class BrowserReadArgs(BaseModel):
+    url: str
+    query: str | None = None
+
+
 class _RegisteredTool:
     def __init__(
         self,
@@ -48,11 +61,14 @@ class _RegisteredTool:
         description: str,
         args_model: type[BaseModel],
         handler: Callable[[BaseModel], object],
+        *,
+        requires_confirmation: bool = False,
     ) -> None:
         self.name = name
         self.description = description
         self.args_model = args_model
         self.handler = handler
+        self.requires_confirmation = requires_confirmation
 
 
 class ToolRegistry:
@@ -67,22 +83,37 @@ class ToolRegistry:
         description: str,
         args_model: type[BaseModel],
         handler: Callable[[BaseModel], object],
+        *,
+        requires_confirmation: bool = False,
     ) -> None:
-        self._tools[name] = _RegisteredTool(name, description, args_model, handler)
+        self._tools[name] = _RegisteredTool(
+            name,
+            description,
+            args_model,
+            handler,
+            requires_confirmation=requires_confirmation,
+        )
 
     def specs(self) -> list[ToolSpec]:
         return [
-            ToolSpec(name=t.name, description=t.description, args_schema=t.args_model.model_json_schema())
+            ToolSpec(
+                name=t.name,
+                description=t.description,
+                args_schema=t.args_model.model_json_schema(),
+                requires_confirmation=t.requires_confirmation,
+            )
             for t in self._tools.values()
         ]
 
     def names(self) -> list[str]:
         return list(self._tools)
 
-    def run(self, name: str, raw_args: dict[str, object]) -> ToolResult:
+    def run(self, name: str, raw_args: dict[str, object], *, confirm: bool = False) -> ToolResult:
         tool = self._tools.get(name)
         if tool is None:
             return ToolResult(ok=False, error=f"unknown tool: {name}")
+        if tool.requires_confirmation and not confirm:
+            return ToolResult(ok=False, error="confirmation required for external action")
         try:
             args = tool.args_model.model_validate(raw_args)
         except ValidationError as exc:
@@ -94,8 +125,13 @@ class ToolRegistry:
         return ToolResult(ok=True, output=output)
 
 
-def build_default_registry(fs_root: Path, store: MemoryStore) -> ToolRegistry:
-    """Register the Phase 17 toolset: read-only filesystem + memory search/write."""
+def build_default_registry(
+    fs_root: Path,
+    store: MemoryStore,
+    web_client: WebClient | None = None,
+    web_sources: WebSourceStore | None = None,
+) -> ToolRegistry:
+    """Register filesystem + memory tools, and (if provided) web tools (Phase 18)."""
     fs = FilesystemTools(fs_root)
     mem = MemoryTools(store)
     registry = ToolRegistry()
@@ -123,4 +159,20 @@ def build_default_registry(fs_root: Path, store: MemoryStore) -> ToolRegistry:
         MemoryWriteArgs,
         lambda a: mem.write(a.content, a.memory_type, a.importance),
     )
+    if web_client is not None and web_sources is not None:
+        web = WebTools(web_client, web_sources)
+        registry.register(
+            "web.search",
+            "Web 検索を行い結果(タイトル/URL)を返す。外部送信のため確認が必要。",
+            WebSearchArgs,
+            lambda a: web.search(a.query, a.limit),
+            requires_confirmation=True,
+        )
+        registry.register(
+            "browser.read",
+            "URL を取得し本文抽出して参照元として保存する。外部送信のため確認が必要。",
+            BrowserReadArgs,
+            lambda a: web.read_url(a.url, a.query),
+            requires_confirmation=True,
+        )
     return registry

--- a/services/agent/src/agent/tools/web.py
+++ b/services/agent/src/agent/tools/web.py
@@ -1,0 +1,209 @@
+"""Web / browser tools (Phase 18).
+
+Pluggable web client (HttpWebClient real / StubWebClient for tests/offline) plus
+a source store so fetched pages can be cited later. Outbound fetches are guarded
+against SSRF (localhost / private IPs / non-http schemes are refused). Marking
+these tools as external + confirmation-gated happens in the registry.
+"""
+
+from __future__ import annotations
+
+import html
+import ipaddress
+import re
+import socket
+from contextlib import closing
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from urllib.parse import urlparse
+from uuid import uuid4
+
+import httpx
+from pydantic import BaseModel
+
+from agent.logger.db import connect
+from agent.tools.base import ToolError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_FETCH_TIMEOUT_S = 20.0
+_MAX_CONTENT_CHARS = 20_000
+_DEFAULT_SEARCH_LIMIT = 5
+_TAG_RE = re.compile(r"<[^>]+>")
+_SCRIPT_STYLE_RE = re.compile(r"<(script|style)[^>]*>.*?</\1>", re.IGNORECASE | re.DOTALL)
+_TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+_WS_RE = re.compile(r"\s+")
+
+_CREATE_SOURCES = """
+CREATE TABLE IF NOT EXISTS web_sources (
+  id         TEXT PRIMARY KEY,
+  url        TEXT NOT NULL,
+  title      TEXT,
+  content    TEXT,
+  query      TEXT,
+  fetched_at TEXT NOT NULL
+)
+"""
+
+
+class SearchResult(BaseModel):
+    """A single web search hit."""
+
+    title: str
+    url: str
+    snippet: str = ""
+
+
+class WebSource(BaseModel):
+    """A fetched page persisted for citation."""
+
+    id: str
+    url: str
+    title: str | None = None
+    content: str | None = None
+    query: str | None = None
+    fetched_at: str
+
+
+@runtime_checkable
+class WebClient(Protocol):
+    """Performs web searches and page fetches."""
+
+    def search(self, query: str, limit: int) -> list[SearchResult]: ...
+    def fetch(self, url: str) -> tuple[str, str]: ...  # (title, text)
+
+
+def _html_to_text(raw: str) -> str:
+    without_scripts = _SCRIPT_STYLE_RE.sub(" ", raw)
+    text = _TAG_RE.sub(" ", without_scripts)
+    return _WS_RE.sub(" ", html.unescape(text)).strip()
+
+
+def _extract_title(raw: str) -> str:
+    match = _TITLE_RE.search(raw)
+    return _WS_RE.sub(" ", html.unescape(match.group(1))).strip() if match else ""
+
+
+def assert_safe_url(url: str) -> None:
+    """Reject non-http(s) schemes and localhost / private / loopback hosts (SSRF guard)."""
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        raise ToolError("only http(s) URLs are allowed")
+    host = parsed.hostname
+    if not host:
+        raise ToolError("invalid URL host")
+    try:
+        infos = socket.getaddrinfo(host, None)
+    except OSError as exc:
+        raise ToolError(f"cannot resolve host: {host}") from exc
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0])
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+            raise ToolError("access to local/internal addresses is denied")
+
+
+class HttpWebClient:
+    """Real web client over httpx. Search uses DuckDuckGo's HTML endpoint (best-effort)."""
+
+    _RESULT_RE = re.compile(r'<a[^>]*class="result__a"[^>]*href="([^"]+)"[^>]*>(.*?)</a>', re.DOTALL)
+
+    def search(self, query: str, limit: int) -> list[SearchResult]:
+        res = httpx.post(
+            "https://html.duckduckgo.com/html/",
+            data={"q": query},
+            timeout=_FETCH_TIMEOUT_S,
+            headers={"User-Agent": "Mozilla/5.0 (avatar-agent)"},
+        )
+        res.raise_for_status()
+        results: list[SearchResult] = []
+        for url, title_html in self._RESULT_RE.findall(res.text)[:limit]:
+            results.append(SearchResult(title=_html_to_text(title_html), url=url, snippet=""))
+        return results
+
+    def fetch(self, url: str) -> tuple[str, str]:
+        assert_safe_url(url)
+        res = httpx.get(
+            url,
+            timeout=_FETCH_TIMEOUT_S,
+            follow_redirects=True,
+            headers={"User-Agent": "Mozilla/5.0 (avatar-agent)"},
+        )
+        res.raise_for_status()
+        return _extract_title(res.text), _html_to_text(res.text)[:_MAX_CONTENT_CHARS]
+
+
+class StubWebClient:
+    """Deterministic offline web client (tests / offline mode)."""
+
+    def __init__(
+        self,
+        results: list[SearchResult] | None = None,
+        pages: dict[str, tuple[str, str]] | None = None,
+    ) -> None:
+        self._results = results or []
+        self._pages = pages or {}
+
+    def search(self, query: str, limit: int) -> list[SearchResult]:
+        _ = query
+        return self._results[:limit]
+
+    def fetch(self, url: str) -> tuple[str, str]:
+        assert_safe_url(url)
+        return self._pages.get(url, ("", f"stub content for {url}"))
+
+
+class WebSourceStore:
+    """Persists fetched web sources for later citation."""
+
+    def __init__(self, db_path: Path) -> None:
+        self._db_path = db_path
+        with closing(connect(db_path)) as conn, conn:
+            conn.execute(_CREATE_SOURCES)
+
+    def save(self, url: str, title: str | None, content: str | None, query: str | None) -> WebSource:
+        source = WebSource(
+            id=uuid4().hex,
+            url=url,
+            title=title,
+            content=content,
+            query=query,
+            fetched_at=datetime.now(tz=UTC).isoformat(),
+        )
+        with closing(connect(self._db_path)) as conn, conn:
+            conn.execute(
+                "INSERT INTO web_sources (id, url, title, content, query, fetched_at) VALUES (?, ?, ?, ?, ?, ?)",
+                (source.id, source.url, source.title, source.content, source.query, source.fetched_at),
+            )
+        return source
+
+    def list_sources(self, *, limit: int = 50) -> list[WebSource]:
+        with closing(connect(self._db_path)) as conn:
+            rows = conn.execute(
+                "SELECT * FROM web_sources ORDER BY fetched_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        return [WebSource(**dict(row)) for row in rows]
+
+
+class WebTools:
+    """web.search / browser.read backed by a WebClient + source store."""
+
+    def __init__(self, client: WebClient, sources: WebSourceStore) -> None:
+        self._client = client
+        self._sources = sources
+
+    def search(self, query: str, limit: int = _DEFAULT_SEARCH_LIMIT) -> list[dict[str, object]]:
+        try:
+            results = self._client.search(query, limit)
+        except (httpx.HTTPError, OSError) as exc:
+            raise ToolError(f"web search failed: {exc}") from exc
+        return [r.model_dump() for r in results]
+
+    def read_url(self, url: str, query: str | None = None) -> dict[str, object]:
+        try:
+            title, text = self._client.fetch(url)
+        except (httpx.HTTPError, OSError) as exc:
+            raise ToolError(f"fetch failed: {exc}") from exc
+        source = self._sources.save(url, title, text, query)
+        return {"url": url, "title": title, "content": text, "source_id": source.id}

--- a/services/agent/tests/web_tools_test.py
+++ b/services/agent/tests/web_tools_test.py
@@ -1,0 +1,83 @@
+"""Tests for web / browser tools (Phase 18), using the deterministic StubWebClient."""
+
+from pathlib import Path
+
+import pytest
+
+from agent.memory.store import MemoryStore
+from agent.tools.base import ToolError
+from agent.tools.registry import build_default_registry
+from agent.tools.web import SearchResult, StubWebClient, WebSourceStore, WebTools, assert_safe_url
+
+
+def _web_tools(tmp_path: Path) -> WebTools:
+    client = StubWebClient(
+        results=[
+            SearchResult(title="知識編集の研究", url="https://example.com/a", snippet="..."),
+            SearchResult(title="別の話題", url="https://example.com/b"),
+        ],
+        pages={"https://example.com/a": ("知識編集の研究", "本文: 知識編集とは...")},
+    )
+    return WebTools(client, WebSourceStore(tmp_path / "app.sqlite"))
+
+
+def test_search_returns_results(tmp_path: Path) -> None:
+    results = _web_tools(tmp_path).search("知識編集", limit=5)
+    assert len(results) == 2
+    assert results[0]["url"] == "https://example.com/a"
+
+
+def test_read_url_saves_source(tmp_path: Path) -> None:
+    db = tmp_path / "app.sqlite"
+    tools = WebTools(
+        StubWebClient(pages={"https://example.com/a": ("タイトル", "本文")}),
+        WebSourceStore(db),
+    )
+    out = tools.read_url("https://example.com/a", query="知識編集")
+    assert out["title"] == "タイトル"
+
+    sources = WebSourceStore(db).list_sources()
+    assert len(sources) == 1
+    assert sources[0].url == "https://example.com/a"
+    assert sources[0].query == "知識編集"
+
+
+def test_ssrf_guard_blocks_localhost() -> None:
+    with pytest.raises(ToolError, match="local/internal"):
+        assert_safe_url("http://127.0.0.1:8123/secret")
+
+
+def test_ssrf_guard_blocks_non_http() -> None:
+    with pytest.raises(ToolError, match="http"):
+        assert_safe_url("file:///etc/passwd")
+
+
+def test_web_tools_require_confirmation(tmp_path: Path) -> None:
+    client = StubWebClient(results=[SearchResult(title="t", url="https://example.com/a")])
+    registry = build_default_registry(
+        tmp_path,
+        MemoryStore(tmp_path / "app.sqlite"),
+        client,
+        WebSourceStore(tmp_path / "app.sqlite"),
+    )
+    # Without confirm → refused.
+    refused = registry.run("web.search", {"query": "x"})
+    assert not refused.ok
+    assert "confirmation required" in refused.error
+    # With confirm → runs.
+    allowed = registry.run("web.search", {"query": "x"}, confirm=True)
+    assert allowed.ok
+    assert len(allowed.output) == 1
+
+
+def test_web_tools_registered_with_confirmation_flag(tmp_path: Path) -> None:
+    registry = build_default_registry(
+        tmp_path,
+        MemoryStore(tmp_path / "app.sqlite"),
+        StubWebClient(),
+        WebSourceStore(tmp_path / "app.sqlite"),
+    )
+    specs = {s.name: s for s in registry.specs()}
+    assert specs["web.search"].requires_confirmation
+    assert specs["browser.read"].requires_confirmation
+    assert not specs["filesystem.read"].requires_confirmation


### PR DESCRIPTION
Web 検索・ページ取得ツール。外部送信は確認必須・SSRF ガード付き。Closes #59

## 内容
- `tools/web.py`: pluggable `WebClient`（HttpWebClient / StubWebClient）。`assert_safe_url` で localhost/内部IP/非http を拒否（SSRF対策）。`WebSourceStore`（web_sources に取得元保存）。`WebTools`（search / read_url）
- `registry`: `requires_confirmation` ゲート。web.search / browser.read を確認必須で登録
- `app.py`: `/tools/{name}` に `confirm`、`GET /web/sources`
- `config`: web_backend("http"|"stub")

## 検証
ruff / format / pytest **61 passed**（ローカル、StubWebClient で決定的）。pyproject 固定。
実Web挙動（DDG検索・実ページ取得）は手動確認が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)