### PR TITLE
feat: TTS + avatar events (Phase 19)

### DIFF
--- a/services/agent/src/agent/app.py
+++ b/services/agent/src/agent/app.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import base64
 import json
 from functools import lru_cache
 from pathlib import Path
 from typing import Annotated
 
+import httpx
 from fastapi import Depends, FastAPI, HTTPException, Query, status
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
@@ -38,6 +40,7 @@ from agent.memory.writer import LLMExtractor, MemoryWriter
 from agent.tools.base import ToolResult, ToolSpec  # noqa: TC001  (FastAPI resolves these at runtime)
 from agent.tools.registry import ToolRegistry, build_default_registry
 from agent.tools.web import HttpWebClient, StubWebClient, WebClient, WebSource, WebSourceStore
+from agent.tts.engine import get_tts_engine, split_sentences
 
 app = FastAPI(title="avatar-agent", version="0.1.0")
 
@@ -237,6 +240,26 @@ class ToolInvokeRequest(BaseModel):
     args: dict[str, object] = {}
     turn_id: str | None = None
     confirm: bool = False
+
+
+class TTSRequest(BaseModel):
+    text: str
+
+
+class TTSResponse(BaseModel):
+    enabled: bool
+    sentences: list[str]
+    audio_base64: str | None = None
+    audio_format: str | None = None
+
+
+class AvatarEventRequest(BaseModel):
+    emotion: str | None = None
+    motion: str | None = None
+    tts_enabled: bool | None = None
+    tts_text: str | None = None
+    started_at: str | None = None
+    ended_at: str | None = None
 
 
 @app.get("/health")
@@ -565,6 +588,42 @@ def invoke_tool(
 @app.get("/web/sources")
 def list_web_sources(sources: WebSourcesDep, limit: int = 50) -> list[WebSource]:
     return sources.list_sources(limit=limit)
+
+
+# ── Phase 19: TTS + avatar events ──────────────────────────────────────────────
+
+
+@app.post("/tts")
+def synthesize_tts(req: TTSRequest) -> TTSResponse:
+    sentences = split_sentences(req.text)
+    if not settings.tts_enabled:
+        # Text-only mode: return sentence segmentation, no audio.
+        return TTSResponse(enabled=False, sentences=sentences)
+    try:
+        audio = get_tts_engine().synthesize(req.text)
+    except (httpx.HTTPError, OSError):
+        audio = b""
+    if not audio:
+        return TTSResponse(enabled=True, sentences=sentences)
+    return TTSResponse(
+        enabled=True,
+        sentences=sentences,
+        audio_base64=base64.b64encode(audio).decode("ascii"),
+        audio_format="wav",
+    )
+
+
+@app.post("/turns/{turn_id}/avatar-events", status_code=status.HTTP_201_CREATED)
+def create_avatar_event(turn_id: str, req: AvatarEventRequest, logger: LoggerDep) -> AvatarEventLog:
+    return logger.log_avatar_event(
+        turn_id,
+        emotion=req.emotion,
+        motion=req.motion,
+        tts_enabled=req.tts_enabled,
+        tts_text=req.tts_text,
+        started_at=req.started_at,
+        ended_at=req.ended_at,
+    )
 
 
 @app.get("/dashboard", response_class=HTMLResponse)

--- a/services/agent/src/agent/config.py
+++ b/services/agent/src/agent/config.py
@@ -30,5 +30,11 @@ class Settings(BaseSettings):
     # Web tools (Phase 18). "http" = real fetch/search, "stub" = offline.
     web_backend: str = "http"  # "http" | "stub"
 
+    # TTS (Phase 19). Off by default → text-only mode works out of the box.
+    tts_enabled: bool = False
+    tts_backend: str = "noop"  # "noop" | "voicevox"
+    voicevox_url: str = "http://127.0.0.1:50021"
+    voicevox_speaker: int = 1
+
 
 settings = Settings()

--- a/services/agent/src/agent/tts/__init__.py
+++ b/services/agent/src/agent/tts/__init__.py
@@ -1,0 +1,1 @@
+"""Text-to-speech: pluggable engines + sentence splitting (Phase 19)."""

--- a/services/agent/src/agent/tts/engine.py
+++ b/services/agent/src/agent/tts/engine.py
@@ -1,0 +1,71 @@
+"""TTS engines + sentence splitting (Phase 19).
+
+Pluggable so the service runs text-only by default (NoopTTSEngine) and tests stay
+deterministic. VoicevoxEngine (opt-in) calls a local VOICEVOX HTTP API. Long text
+is split into sentences for chunked synthesis / lip-sync timing on the UI side.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Protocol, runtime_checkable
+
+import httpx
+
+from agent.config import settings
+
+# Japanese sentence terminators (full-width period/exclamation/question) are
+# intentional here; the regex must match them to split Japanese text.
+_SENTENCE_RE = re.compile(r"[^。．！？!?\n]+[。．！？!?]?")  # noqa: RUF001
+_TTS_TIMEOUT_S = 30.0
+
+
+def split_sentences(text: str) -> list[str]:
+    """Split text into sentences on Japanese/ASCII terminators and newlines."""
+    return [s.strip() for s in _SENTENCE_RE.findall(text) if s.strip()]
+
+
+@runtime_checkable
+class TTSEngine(Protocol):
+    """Synthesizes speech audio (WAV bytes) from text; empty bytes if unavailable."""
+
+    def synthesize(self, text: str) -> bytes: ...
+
+
+class NoopTTSEngine:
+    """No-op engine for text-only mode / tests (returns no audio)."""
+
+    def synthesize(self, text: str) -> bytes:
+        _ = text
+        return b""
+
+
+class VoicevoxEngine:
+    """Synthesize via a local VOICEVOX HTTP API (opt-in; requires VOICEVOX running)."""
+
+    def __init__(self, base_url: str, speaker: int) -> None:
+        self._base_url = base_url
+        self._speaker = speaker
+
+    def synthesize(self, text: str) -> bytes:
+        query = httpx.post(
+            f"{self._base_url}/audio_query",
+            params={"text": text, "speaker": self._speaker},
+            timeout=_TTS_TIMEOUT_S,
+        )
+        query.raise_for_status()
+        synthesis = httpx.post(
+            f"{self._base_url}/synthesis",
+            params={"speaker": self._speaker},
+            json=query.json(),
+            timeout=_TTS_TIMEOUT_S,
+        )
+        synthesis.raise_for_status()
+        return synthesis.content
+
+
+def get_tts_engine() -> TTSEngine:
+    """Return the configured TTS engine (noop by default, voicevox when requested)."""
+    if settings.tts_backend == "voicevox":
+        return VoicevoxEngine(settings.voicevox_url, settings.voicevox_speaker)
+    return NoopTTSEngine()

--- a/services/agent/tests/tts_test.py
+++ b/services/agent/tests/tts_test.py
@@ -1,0 +1,58 @@
+"""Tests for TTS engine + sentence splitting + avatar events (Phase 19)."""
+
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agent.app import app, get_logger
+from agent.logger.interaction_logger import InteractionLogger
+from agent.tts.engine import NoopTTSEngine, split_sentences
+
+
+def test_split_sentences_japanese_and_newlines() -> None:
+    sentences = split_sentences("こんにちは。元気です。\nそうですね。")
+    assert sentences == ["こんにちは。", "元気です。", "そうですね。"]
+
+
+def test_split_sentences_ignores_empty() -> None:
+    assert split_sentences("   \n  ") == []
+
+
+def test_noop_engine_returns_no_audio() -> None:
+    assert NoopTTSEngine().synthesize("読み上げて") == b""
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> Iterator[TestClient]:
+    app.dependency_overrides[get_logger] = lambda: InteractionLogger(tmp_path / "app.sqlite")
+    yield TestClient(app)
+    app.dependency_overrides.clear()
+
+
+def test_tts_text_only_mode(client: TestClient) -> None:
+    # Default config has tts_enabled=False → text-only mode (no audio, still segments).
+    res = client.post("/tts", json={"text": "こんにちは。元気です。"})
+    assert res.status_code == 200
+    body = res.json()
+    assert body["enabled"] is False
+    assert body["sentences"] == ["こんにちは。", "元気です。"]
+    assert body["audio_base64"] is None
+
+
+def test_avatar_event_roundtrip(client: TestClient) -> None:
+    session_id = client.post("/sessions", json={"model": "gemma4:31b"}).json()["id"]
+    turn_id = client.post(f"/sessions/{session_id}/turns", json={"user_input": "やあ"}).json()["id"]
+
+    created = client.post(
+        f"/turns/{turn_id}/avatar-events",
+        json={"emotion": "happy", "motion": "nod", "tts_enabled": True, "tts_text": "どうも"},
+    )
+    assert created.status_code == 201
+    assert created.json()["emotion"] == "happy"
+
+    events = client.get(f"/turns/{turn_id}/avatar-events")
+    assert events.status_code == 200
+    assert len(events.json()) == 1
+    assert events.json()[0]["tts_enabled"] is True


### PR DESCRIPTION
音声読み上げ基盤とアバターイベント記録。TTS は既定 OFF = テキストのみで動く。Closes #60

## 内容
- `tts/engine.py`: pluggable TTSEngine（NoopTTSEngine 既定 / VoicevoxEngine opt-in）+ split_sentences
- `config`: tts_enabled(既定False) / tts_backend / voicevox_url / voicevox_speaker
- `app.py`: POST /tts、POST /turns/{id}/avatar-events（avatar_event_logs 書き込み）

## 検証
ruff / format / pytest **66 passed**（ローカル）。pyproject 固定。
実音声(VOICEVOX)と UI 音声再生の最終配線は手動確認が必要。

> マージで Phase 8–19（要件定義 v2 全フェーズ）が main に揃う。

🤖 Generated with [Claude Code](https://claude.com/claude-code)