### PR TITLE
feat: 会話で実ツールを使う agentic tool-calling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,11 @@ BRIDGE_PORT=3000
 # Bind to localhost only (never 0.0.0.0 for security)
 BRIDGE_HOST=127.0.0.1
 
-# ─── Python agent service (FastAPI: logging / feedback / analytics) ────────────
+# ─── Python agent service (FastAPI: logging / feedback / analytics / tools) ────
 # `pnpm dev:agent` で起動。停止していても会話は動く（ログ・フィードバックは best-effort）
 AGENT_SERVICE_URL=http://127.0.0.1:8123
+# 会話で実ツール（web.search 等）を使う agentic tool-calling。0 で無効化
+TOOL_USE_ENABLED=1
 
 # ─── OpenClaw Gateway (Phase 3) ───────────────────────────────────────────────
 # Uncomment and fill when setting up OpenClaw integration

--- a/apps/bridge/src/brain.test.ts
+++ b/apps/bridge/src/brain.test.ts
@@ -8,6 +8,7 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { extractJSON, stripLLMNoise } from "@avatar-agent/utils";
 import { parseRenderEvent, isValidEmotion, isValidMotion } from "@avatar-agent/schema";
+import { parseToolCalls } from "./brain.js";
 
 // ── stripLLMNoise ─────────────────────────────────────────────────────────────
 describe("stripLLMNoise", () => {
@@ -156,5 +157,41 @@ describe("Full parse pipeline (simulate Ollama output → RenderEvent)", () => {
     const raw = '{"text":"","emotion":"happy"}';
     const ev = pipelineFrom(raw);
     assert.equal(ev, null);
+  });
+});
+
+// ── parseToolCalls (agentic tool-calling, #69) ────────────────────────────────
+describe("parseToolCalls", () => {
+  test("parses a web.search tool call", () => {
+    const calls = parseToolCalls('{"tool_calls":[{"name":"web.search","args":{"query":"東京 天気"}}]}');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]!.name, "web.search");
+    assert.equal(calls[0]!.args["query"], "東京 天気");
+  });
+
+  test("empty tool_calls → []", () => {
+    assert.deepEqual(parseToolCalls('{"tool_calls":[]}'), []);
+  });
+
+  test("no tool_calls field / junk → []", () => {
+    assert.deepEqual(parseToolCalls('{"text":"hi"}'), []);
+    assert.deepEqual(parseToolCalls("not json"), []);
+  });
+
+  test("missing args defaults to {}", () => {
+    const calls = parseToolCalls('{"tool_calls":[{"name":"memory.search"}]}');
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0]!.args, {});
+  });
+
+  test("caps at 2 tool calls", () => {
+    const raw = '{"tool_calls":[{"name":"a"},{"name":"b"},{"name":"c"}]}';
+    assert.equal(parseToolCalls(raw).length, 2);
+  });
+
+  test("drops entries without a string name", () => {
+    const calls = parseToolCalls('{"tool_calls":[{"args":{}},{"name":"web.search","args":{}}]}');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]!.name, "web.search");
   });
 });

--- a/apps/bridge/src/brain.ts
+++ b/apps/bridge/src/brain.ts
@@ -117,6 +117,102 @@ interface OllamaMetrics {
   tokensPerSec?: number;
 }
 
+// ── Tool use: plan → execute (Python agent) → ground the answer (#69) ──────────
+const TOOL_USE_ENABLED = process.env["TOOL_USE_ENABLED"] !== "0";
+const MAX_TOOL_CALLS = 2;
+const TOOL_EXEC_TIMEOUT_MS = 30_000;
+const TOOL_OUTPUT_MAX = 1500;
+
+export interface ToolCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+const TOOL_PLANNING_PROMPT = `\
+あなたはツール使用プランナー。ユーザー発話に答えるのに外部ツールが要るか判断する。
+返答は必ずJSON1行のみ: {"tool_calls":[{"name":"...","args":{...}}]}
+不要なら {"tool_calls":[]}。
+
+使えるツール:
+- web.search {"query":"検索語"} : 最新情報・天気・ニュース・調べもの
+- browser.read {"url":"https://..."} : 特定URLの本文取得
+- memory.search {"query":"語"} : 過去の記憶を検索
+
+天気・最新情報・事実確認はためらわず web.search を使う。挨拶や雑談は空配列。`;
+
+/** Parse the planner's JSON into at most MAX_TOOL_CALLS valid tool calls. Pure (tested). */
+export function parseToolCalls(raw: string): ToolCall[] {
+  const parsed = extractJSON(repairJSON(raw));
+  const calls = parsed?.["tool_calls"];
+  if (!Array.isArray(calls)) return [];
+  const out: ToolCall[] = [];
+  for (const c of calls) {
+    if (c && typeof c === "object" && typeof (c as Record<string, unknown>)["name"] === "string") {
+      const rec = c as Record<string, unknown>;
+      const args = rec["args"];
+      out.push({ name: rec["name"] as string, args: (args && typeof args === "object" ? args : {}) as Record<string, unknown> });
+    }
+    if (out.length >= MAX_TOOL_CALLS) break;
+  }
+  return out;
+}
+
+async function callOllamaJSON(system: string, userContent: string): Promise<string> {
+  const res = await fetch(`${config.ollama.baseUrl}/api/chat`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      model: currentModel,
+      stream: false,
+      think: false,
+      format: "json",
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: userContent },
+      ],
+      options: { temperature: 0, num_predict: 200 },
+    }),
+    signal: AbortSignal.timeout(config.ollama.timeoutMs),
+  });
+  if (!res.ok) throw new Error(`Ollama ${res.status}`);
+  const data = await res.json() as { message?: { content?: string } };
+  return data.message?.content ?? "";
+}
+
+async function planTools(userMessage: string): Promise<ToolCall[]> {
+  try {
+    return parseToolCalls(await callOllamaJSON(TOOL_PLANNING_PROMPT, userMessage));
+  } catch (e) {
+    log.warn("tool planning failed", e);
+    return [];
+  }
+}
+
+/** Execute planned tools via the Python agent service. Read-only web is auto-confirmed. */
+async function executeTools(calls: ToolCall[], broadcast: (event: UIEvent) => void): Promise<string> {
+  const base = config.agentService.baseUrl;
+  const blocks: string[] = [];
+  for (const call of calls) {
+    broadcast({ type: "status", state: "running", message: `ツール実行中: ${call.name}` });
+    try {
+      const res = await fetch(`${base}/tools/${call.name}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ args: call.args, confirm: true }),
+        signal: AbortSignal.timeout(TOOL_EXEC_TIMEOUT_MS),
+      });
+      if (!res.ok) continue;
+      const data = await res.json() as { ok: boolean; output?: unknown; error?: string };
+      blocks.push(data.ok
+        ? `## ${call.name}\n${truncate(JSON.stringify(data.output), TOOL_OUTPUT_MAX)}`
+        : `## ${call.name}: エラー ${data.error ?? ""}`);
+    } catch (e) {
+      log.warn(`tool ${call.name} failed`, e);
+    }
+  }
+  return blocks.join("\n\n");
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 export async function ask(
   userMessage: string,
@@ -143,12 +239,24 @@ export async function ask(
   history.push({ role: "user", content: userMessage });
   trimHistory();
 
+  // Agentic tool use: plan tools, execute via the Python agent, ground the answer.
+  let systemPrompt = systemWithMemory;
+  if (TOOL_USE_ENABLED && config.brainBackend === "ollama") {
+    const calls = await planTools(userMessage);
+    if (calls.length > 0) {
+      const toolContext = await executeTools(calls, broadcast);
+      if (toolContext) {
+        systemPrompt = `${systemWithMemory}\n\n# ツール実行結果(この事実に基づいて答える)\n${toolContext}`;
+      }
+    }
+  }
+
   const startMs = Date.now();
 
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
     try {
       const { text, emotion, motion, rawBuffer, tokensPerSec, ttftMs } = await streamOllamaResponse(
-        systemWithMemory,
+        systemPrompt,
         history,
         broadcast,
       );


### PR DESCRIPTION
LLM が「調べるね」と言うだけで実行されなかった問題を解消。会話ループにツール実行を配線。Closes #69

## 内容
- `brain.ts ask()`: 計画→実行→接地→回答
  - `planTools()` 非ストリーミング LLM でツール要否判定（web.search/browser.read/memory.search）
  - `executeTools()` Python `POST /tools/{name}`（read-only web は confirm:true 自動）→ 結果を system prompt に注入
  - `TOOL_USE_ENABLED=0` で無効化、agent 停止/失敗時はフォールバック
- `parseToolCalls()` を pure 関数化し brain.test.ts で 6 ケース検証

## 検証
pnpm typecheck ✅ / bridge test 38 passed（parseToolCalls 6 含む）。
LLM 実挙動（gemma4 のツール選択・接地）は ollama 手動確認が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)