### PR TITLE
fix: web ツールの TLS 検証を OS 信頼ストア(truststore)に切替

### DIFF
--- a/services/agent/pyproject.toml
+++ b/services/agent/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "pydantic-settings>=2.4.0",
     "python-dotenv>=1.0.0",
+    "truststore>=0.10.0",
 ]
 
 [dependency-groups]

--- a/services/agent/src/agent/tools/web.py
+++ b/services/agent/src/agent/tools/web.py
@@ -12,6 +12,7 @@ import html
 import ipaddress
 import re
 import socket
+import ssl
 from contextlib import closing
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
@@ -19,6 +20,7 @@ from urllib.parse import urlparse
 from uuid import uuid4
 
 import httpx
+import truststore
 from pydantic import BaseModel
 
 from agent.logger.db import connect
@@ -30,6 +32,9 @@ if TYPE_CHECKING:
 _FETCH_TIMEOUT_S = 20.0
 _MAX_CONTENT_CHARS = 20_000
 _DEFAULT_SEARCH_LIMIT = 5
+# Verify TLS against the OS trust store so corporate MITM proxies (self-signed
+# root CA) work — the default certifi bundle rejects them.
+_VERIFY = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 _TAG_RE = re.compile(r"<[^>]+>")
 _SCRIPT_STYLE_RE = re.compile(r"<(script|style)[^>]*>.*?</\1>", re.IGNORECASE | re.DOTALL)
 _TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
@@ -114,6 +119,7 @@ class HttpWebClient:
             data={"q": query},
             timeout=_FETCH_TIMEOUT_S,
             headers={"User-Agent": "Mozilla/5.0 (avatar-agent)"},
+            verify=_VERIFY,
         )
         res.raise_for_status()
         results: list[SearchResult] = []
@@ -128,6 +134,7 @@ class HttpWebClient:
             timeout=_FETCH_TIMEOUT_S,
             follow_redirects=True,
             headers={"User-Agent": "Mozilla/5.0 (avatar-agent)"},
+            verify=_VERIFY,
         )
         res.raise_for_status()
         return _extract_title(res.text), _html_to_text(res.text)[:_MAX_CONTENT_CHARS]

--- a/services/agent/uv.lock
+++ b/services/agent/uv.lock
@@ -43,6 +43,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "truststore" },
     { name = "uvicorn" },
 ]
 
@@ -60,6 +61,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.4.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "truststore", specifier = ">=0.10.0" },
     { name = "uvicorn", specifier = ">=0.32.0" },
 ]
 
@@ -500,6 +502,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/80/cc/44f2d81d8f9093aad81c3467a5bf5718d2b5f786e887b6e4adcfc17ec6b9/tcolorpy-0.1.7.tar.gz", hash = "sha256:0fbf6bf238890bbc2e32662aa25736769a29bf6d880328f310c910a327632614", size = 299437, upload-time = "2024-12-29T15:24:23.847Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/05/a2/ed023f2edd1e011b4d99b6727bce8253842d66c3fbf9ed0a26fc09a92571/tcolorpy-0.1.7-py3-none-any.whl", hash = "sha256:26a59d52027e175a37e0aba72efc99dda43f074db71f55b316d3de37d3251378", size = 8096, upload-time = "2024-12-29T15:24:21.33Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
社内 MITM プロキシ（自己署名ルートCA）環境で web.search / browser.read が `[SSL: CERTIFICATE_VERIFY_FAILED]` で失敗していた問題の修正（#69 の tool-calling が「調べられなかった」で終わる原因）。

## 内容
- `truststore` 依存を追加し、`HttpWebClient` の httpx 呼び出しに OS 信頼ストア由来の `SSLContext` を `verify=` で渡す（社内ルートCAを認識）

## 検証
- 実ネットワークで `web.search` が結果を返すことを確認（tenki.jp / ウェザーニュース / Yahoo!天気）
- ruff / format / pytest 66 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)