### PR TITLE
feat: weather ツール（wttr.in）で天気質問に実データ回答

### DIFF
--- a/apps/bridge/src/brain.ts
+++ b/apps/bridge/src/brain.ts
@@ -134,11 +134,12 @@ const TOOL_PLANNING_PROMPT = `\
 不要なら {"tool_calls":[]}。
 
 使えるツール:
-- web.search {"query":"検索語"} : 最新情報・天気・ニュース・調べもの
+- weather {"location":"都市名(空で現在地)"} : 天気・気温・天候
+- web.search {"query":"検索語"} : 最新情報・ニュース・調べもの
 - browser.read {"url":"https://..."} : 特定URLの本文取得
 - memory.search {"query":"語"} : 過去の記憶を検索
 
-天気・最新情報・事実確認はためらわず web.search を使う。挨拶や雑談は空配列。`;
+天気・気温は weather を使う。最新情報・事実確認は web.search。挨拶や雑談は空配列。`;
 
 /** Parse the planner's JSON into at most MAX_TOOL_CALLS valid tool calls. Pure (tested). */
 export function parseToolCalls(raw: string): ToolCall[] {

--- a/services/agent/src/agent/tools/registry.py
+++ b/services/agent/src/agent/tools/registry.py
@@ -10,6 +10,7 @@ from agent.memory.store import MemoryType  # noqa: TC001  (pydantic field type, 
 from agent.tools.base import ToolError, ToolResult, ToolSpec
 from agent.tools.filesystem import FilesystemTools
 from agent.tools.memory_tools import MemoryTools
+from agent.tools.weather import get_weather
 from agent.tools.web import WebTools
 
 if TYPE_CHECKING:
@@ -52,6 +53,10 @@ class WebSearchArgs(BaseModel):
 class BrowserReadArgs(BaseModel):
     url: str
     query: str | None = None
+
+
+class WeatherArgs(BaseModel):
+    location: str = ""
 
 
 class _RegisteredTool:
@@ -158,6 +163,13 @@ def build_default_registry(
         "長期記憶に新しい項目を保存する",
         MemoryWriteArgs,
         lambda a: mem.write(a.content, a.memory_type, a.importance),
+    )
+    registry.register(
+        "weather",
+        "現在の天気・気温を返す(location は都市名、空なら現在地)。外部送信のため確認が必要。",
+        WeatherArgs,
+        lambda a: get_weather(a.location),
+        requires_confirmation=True,
     )
     if web_client is not None and web_sources is not None:
         web = WebTools(web_client, web_sources)

--- a/services/agent/src/agent/tools/weather.py
+++ b/services/agent/src/agent/tools/weather.py
@@ -1,0 +1,55 @@
+"""Weather tool via wttr.in (Phase: reliable factual answers).
+
+Generic web search returns only links and page scraping is too noisy/JS-heavy to
+read live forecasts. wttr.in returns structured current conditions (and geolocates
+by IP when no location is given), so the agent can actually state the weather.
+"""
+
+from __future__ import annotations
+
+import ssl
+
+import httpx
+import truststore
+
+from agent.tools.base import ToolError
+
+# Verify TLS against the OS trust store (corporate MITM proxies use a self-signed CA).
+_VERIFY = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+_TIMEOUT_S = 15.0
+
+
+def parse_wttr(data: dict[str, object]) -> dict[str, object]:
+    """Extract concise current-condition fields from a wttr.in j1 response."""
+    conditions = data["current_condition"]
+    if not isinstance(conditions, list) or not conditions:
+        raise ToolError("unexpected weather response")
+    current = conditions[0]
+    areas = data.get("nearest_area")
+    location = ""
+    if isinstance(areas, list) and areas:
+        names = areas[0].get("areaName")
+        if isinstance(names, list) and names:
+            location = names[0].get("value", "")
+    return {
+        "location": location,
+        "temp_c": current.get("temp_C"),
+        "feels_like_c": current.get("FeelsLikeC"),
+        "humidity": current.get("humidity"),
+        "description": current.get("weatherDesc", [{}])[0].get("value", ""),
+    }
+
+
+def get_weather(location: str = "") -> dict[str, object]:
+    """Fetch current weather for `location` (empty = IP-based current location)."""
+    try:
+        res = httpx.get(
+            f"https://wttr.in/{location}?format=j1&lang=ja",
+            timeout=_TIMEOUT_S,
+            verify=_VERIFY,
+            headers={"User-Agent": "curl/8"},
+        )
+        res.raise_for_status()
+        return parse_wttr(res.json())
+    except (httpx.HTTPError, KeyError, IndexError, OSError) as exc:
+        raise ToolError(f"weather lookup failed: {exc}") from exc

--- a/services/agent/tests/tools_test.py
+++ b/services/agent/tests/tools_test.py
@@ -70,4 +70,4 @@ def test_registry_invalid_args(tmp_path: Path) -> None:
 def test_specs_list_all_tools(tmp_path: Path) -> None:
     registry = build_default_registry(tmp_path, MemoryStore(tmp_path / "app.sqlite"))
     names = {s.name for s in registry.specs()}
-    assert names == {"filesystem.list", "filesystem.read", "memory.search", "memory.write"}
+    assert names == {"filesystem.list", "filesystem.read", "memory.search", "memory.write", "weather"}

--- a/services/agent/tests/weather_test.py
+++ b/services/agent/tests/weather_test.py
@@ -1,0 +1,37 @@
+"""Tests for the weather tool's wttr.in parsing (Phase: factual answers)."""
+
+import pytest
+
+from agent.tools.base import ToolError
+from agent.tools.weather import parse_wttr
+
+_SAMPLE = {
+    "current_condition": [
+        {
+            "temp_C": "25",
+            "FeelsLikeC": "26",
+            "humidity": "60",
+            "weatherDesc": [{"value": "晴れ"}],
+        },
+    ],
+    "nearest_area": [{"areaName": [{"value": "Tokyo"}]}],
+}
+
+
+def test_parse_wttr_extracts_fields() -> None:
+    out = parse_wttr(_SAMPLE)
+    assert out["location"] == "Tokyo"
+    assert out["temp_c"] == "25"
+    assert out["feels_like_c"] == "26"
+    assert out["description"] == "晴れ"
+
+
+def test_parse_wttr_without_area() -> None:
+    out = parse_wttr({"current_condition": [{"temp_C": "20", "weatherDesc": [{"value": "曇り"}]}]})
+    assert out["location"] == ""
+    assert out["temp_c"] == "20"
+
+
+def test_parse_wttr_rejects_empty() -> None:
+    with pytest.raises(ToolError, match="unexpected"):
+        parse_wttr({"current_condition": []})


### PR DESCRIPTION
「今日の天気は？」に答えられない問題の修正。web.search はリンクのみ・browser.read はノイズでライブ天気が取れないため、構造化天気を返す wttr.in ベースの `weather` ツールを追加。

## 内容
- `tools/weather.py`: `get_weather(location="")`（wttr.in j1 + truststore、location 空で IP 現在地）。`parse_wttr` は pure 関数
- `registry`: weather を登録（requires_confirmation、chat は自動確認）
- `brain.ts`: 計画プロンプトに weather を追加

## 検証（社内環境で実機）
- `/tools/weather` → `{temp_c, feels_like_c, humidity, description}`、location 空で現在地
- gemma4 が「今日の天気は？」で weather を選択
- pytest 69 passed / TS typecheck / bridge test 38 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)