### PR TITLE
feat: filesystem.search（再帰ファイル検索）+ tools_root を home 既定に

### DIFF
--- a/apps/bridge/src/brain.ts
+++ b/apps/bridge/src/brain.ts
@@ -137,9 +137,10 @@ const TOOL_PLANNING_PROMPT = `\
 - weather {"location":"都市名(空で現在地)"} : 天気・気温・天候
 - web.search {"query":"検索語"} : 最新情報・ニュース・調べもの
 - browser.read {"url":"https://..."} : 特定URLの本文取得
+- filesystem.search {"pattern":"*.pptx"} : PC内のファイルを名前/拡張子で探す
 - memory.search {"query":"語"} : 過去の記憶を検索
 
-天気・気温は weather を使う。最新情報・事実確認は web.search。挨拶や雑談は空配列。`;
+天気・気温は weather。最新情報・事実確認は web.search。ファイル探索は filesystem.search。挨拶や雑談は空配列。`;
 
 /** Parse the planner's JSON into at most MAX_TOOL_CALLS valid tool calls. Pure (tested). */
 export function parseToolCalls(raw: string): ToolCall[] {

--- a/services/agent/src/agent/config.py
+++ b/services/agent/src/agent/config.py
@@ -17,8 +17,9 @@ class Settings(BaseSettings):
     ollama_model: str = "gemma4:31b"
     ollama_timeout_ms: int = 120_000
     storage_dir: str = "./storage"
-    # Root directory that filesystem tools (Phase 17) may list/read within.
-    tools_root: str = "."
+    # Root directory that filesystem tools (Phase 17+) may list/read/search within.
+    # Defaults to the user's home so "find my files" works; narrow via TOOLS_ROOT.
+    tools_root: str = "~"
 
     # Memory retrieval embeddings (Phase 13). "hash" = offline/deterministic default.
     embedding_backend: str = "hash"  # "hash" | "ollama"

--- a/services/agent/src/agent/tools/filesystem.py
+++ b/services/agent/src/agent/tools/filesystem.py
@@ -6,6 +6,8 @@ outside the root and access to credential-ish files are denied.
 
 from __future__ import annotations
 
+import fnmatch
+import os
 from pathlib import Path
 
 from agent.tools.base import ToolError
@@ -27,13 +29,17 @@ _DENY_SUBSTRINGS = (
     ".aws",
 )
 _MAX_READ_BYTES = 1_000_000
+# Directory names pruned during recursive search (noise / heavy / sensitive).
+_SKIP_DIRS = frozenset({"node_modules", "__pycache__", ".venv", "venv", "Library", ".Trash", "dist", "build"})
+_SEARCH_MAX_RESULTS = 50
+_SEARCH_MAX_SCAN = 20_000
 
 
 class FilesystemTools:
     """Read-only filesystem access scoped to a root directory."""
 
     def __init__(self, root: Path) -> None:
-        self._root = Path(root).resolve()
+        self._root = Path(root).expanduser().resolve()
 
     def _resolve(self, rel_path: str) -> Path:
         target = (self._root / rel_path).resolve()
@@ -67,3 +73,31 @@ class FilesystemTools:
         if size > _MAX_READ_BYTES:
             raise ToolError(f"file too large ({size} bytes, limit {_MAX_READ_BYTES})")
         return {"path": path, "content": target.read_text(encoding="utf-8", errors="replace")}
+
+    def search(self, pattern: str, path: str = ".") -> list[dict[str, object]]:
+        """Recursively find files matching a glob `pattern` (e.g. '*.pptx') under the root.
+
+        Prunes hidden / heavy dirs, skips sensitive files, and is capped in results
+        and files scanned so a large home directory stays responsive.
+        """
+        base = self._resolve(path)
+        if not base.is_dir():
+            raise ToolError("not a directory")
+        needle = pattern.lower()
+        results: list[dict[str, object]] = []
+        scanned = 0
+        for dirpath, dirnames, filenames in os.walk(base):
+            dirnames[:] = [d for d in dirnames if not d.startswith(".") and d not in _SKIP_DIRS]
+            for name in filenames:
+                scanned += 1
+                if scanned > _SEARCH_MAX_SCAN:
+                    return results
+                if not fnmatch.fnmatch(name.lower(), needle):
+                    continue
+                full = Path(dirpath) / name
+                if any(token in str(full).lower() for token in _DENY_SUBSTRINGS):
+                    continue
+                results.append({"path": str(full.relative_to(self._root)), "size": full.stat().st_size})
+                if len(results) >= _SEARCH_MAX_RESULTS:
+                    return results
+        return results

--- a/services/agent/src/agent/tools/registry.py
+++ b/services/agent/src/agent/tools/registry.py
@@ -33,6 +33,11 @@ class FilesystemReadArgs(BaseModel):
     path: str
 
 
+class FilesystemSearchArgs(BaseModel):
+    pattern: str
+    path: str = "."
+
+
 class MemorySearchArgs(BaseModel):
     query: str
     memory_type: MemoryType | None = None
@@ -151,6 +156,12 @@ def build_default_registry(
         "指定ファイル(許可ルート内、機微ファイルは除外)の内容を返す",
         FilesystemReadArgs,
         lambda a: fs.read_file(a.path),
+    )
+    registry.register(
+        "filesystem.search",
+        "許可ルート内をファイル名/拡張子で再帰検索する(例 pattern='*.pptx')",
+        FilesystemSearchArgs,
+        lambda a: fs.search(a.pattern, a.path),
     )
     registry.register(
         "memory.search",

--- a/services/agent/tests/filesystem_search_test.py
+++ b/services/agent/tests/filesystem_search_test.py
@@ -1,0 +1,43 @@
+"""Tests for recursive filesystem.search (file discovery)."""
+
+from pathlib import Path
+
+from agent.tools.filesystem import FilesystemTools
+
+
+def _workspace(tmp_path: Path) -> Path:
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "自己紹介.pptx").write_text("x", encoding="utf-8")
+    (tmp_path / "docs" / "memo.txt").write_text("x", encoding="utf-8")
+    (tmp_path / "sub" / "deep").mkdir(parents=True)
+    (tmp_path / "sub" / "deep" / "slides.pptx").write_text("x", encoding="utf-8")
+    # Pruned/sensitive entries that must NOT surface.
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "ignored.pptx").write_text("x", encoding="utf-8")
+    (tmp_path / ".secret.pptx").write_text("x", encoding="utf-8")
+    return tmp_path
+
+
+def test_search_finds_files_recursively(tmp_path: Path) -> None:
+    fs = FilesystemTools(_workspace(tmp_path))
+    hits = {Path(h["path"]).name for h in fs.search("*.pptx")}
+    assert "自己紹介.pptx" in hits
+    assert "slides.pptx" in hits  # nested
+
+
+def test_search_prunes_heavy_and_hidden(tmp_path: Path) -> None:
+    fs = FilesystemTools(_workspace(tmp_path))
+    paths = {h["path"] for h in fs.search("*.pptx")}
+    assert not any("node_modules" in p for p in paths)  # pruned dir
+    assert not any(".secret" in p for p in paths)  # deny-listed
+
+
+def test_search_name_substring(tmp_path: Path) -> None:
+    fs = FilesystemTools(_workspace(tmp_path))
+    hits = {Path(h["path"]).name for h in fs.search("*自己紹介*")}
+    assert hits == {"自己紹介.pptx"}
+
+
+def test_search_no_match(tmp_path: Path) -> None:
+    fs = FilesystemTools(_workspace(tmp_path))
+    assert fs.search("*.xlsx") == []

--- a/services/agent/tests/tools_test.py
+++ b/services/agent/tests/tools_test.py
@@ -70,4 +70,11 @@ def test_registry_invalid_args(tmp_path: Path) -> None:
 def test_specs_list_all_tools(tmp_path: Path) -> None:
     registry = build_default_registry(tmp_path, MemoryStore(tmp_path / "app.sqlite"))
     names = {s.name for s in registry.specs()}
-    assert names == {"filesystem.list", "filesystem.read", "memory.search", "memory.write", "weather"}
+    assert names == {
+        "filesystem.list",
+        "filesystem.read",
+        "filesystem.search",
+        "memory.search",
+        "memory.write",
+        "weather",
+    }


### PR DESCRIPTION
「PC内のファイルを探して」が動かない問題の修正。再帰検索ツールが無く、tools_root が `.`（実行dir）だった。

## 内容
- `filesystem.search(pattern, path=".")`: os.walk で再帰、隠し/重い dir 除外、機微ファイルは deny-list、件数(50)・走査(20000)上限。root を expanduser 解決
- `registry`: filesystem.search を登録
- `config`: tools_root 既定を `~`(home) に（TOOLS_ROOT で絞れる）
- `brain.ts`: 計画プロンプトに filesystem.search 追加

## 検証（社内環境で実機）
- `/tools/filesystem.search '*.md'` → 9件（再帰・除外OK）
- gemma4 が「パワポを探して」で filesystem.search + pattern `*自己紹介*.pptx` を生成
- pytest 73 passed / TS typecheck / bridge test 38 passed

## ⚠️ スコープ
tools_root 既定が home に。read-only・deny-list・上限あり。絞るなら `TOOLS_ROOT` を設定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)