### PR TITLE
fix: ツール結果がある時は応答フォーマットを緩める

### DIFF
--- a/apps/bridge/src/brain.ts
+++ b/apps/bridge/src/brain.ts
@@ -248,7 +248,12 @@ export async function ask(
     if (calls.length > 0) {
       const toolContext = await executeTools(calls, broadcast);
       if (toolContext) {
-        systemPrompt = `${systemWithMemory}\n\n# ツール実行結果(この事実に基づいて答える)\n${toolContext}`;
+        // Tool results often contain paths/URLs/numbers, so relax the short-answer
+        // format: allow longer text and symbols (/ . : etc.) to report specifics.
+        systemPrompt =
+          `${systemWithMemory}\n\n# ツール実行結果(この事実に基づいて具体的に答える)\n${toolContext}\n\n` +
+          "※この結果を使うときは text の制約を緩める: 40〜140文字可、ファイルパス・URL・数値・記号を含めてよい。" +
+          "見つかったファイル名やパスは具体的に答える。該当が無ければ正直に無いと言う。";
       }
     }
   }


### PR DESCRIPTION
ファイル検索が「探してみるね」で止まる真因の修正。SYSTEM_PROMPT の「text は15〜35文字・！以外の記号禁止」制約で、ファイルパス（/・.）や URL を出力できず、ツールが結果を返しても具体的に答えられなかった。

## 内容
- ツール結果を注入する際、text 制約を上書き（40〜140文字・パス/URL/数値/記号可、該当無しは正直に）

## 検証
- gemma4 に検索結果を渡すと実際のファイルパスを列挙して回答することを確認
- TS typecheck / bridge test 38 passed

※反映には `pnpm dev:all` の再起動が必要。検索はファイル名パターン一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)