### PR TITLE
feat: ツール実行を tool_call_logs に記録（観測性）

### DIFF
--- a/apps/bridge/src/brain.ts
+++ b/apps/bridge/src/brain.ts
@@ -187,7 +187,11 @@ async function callOllamaJSON(system: string, userContent: string): Promise<stri
  * empty or insufficient — instead of giving up after one try. Returns the
  * accumulated tool-result transcript (empty string if no tools were used).
  */
-async function runAgentLoop(userMessage: string, broadcast: (event: UIEvent) => void): Promise<string> {
+async function runAgentLoop(
+  userMessage: string,
+  broadcast: (event: UIEvent) => void,
+  turnId: string | null,
+): Promise<string> {
   const transcript: string[] = [];
   for (let step = 0; step < MAX_AGENT_STEPS; step++) {
     const soFar = transcript.length > 0 ? `\n\n# これまでのツール結果\n${transcript.join("\n\n")}` : "";
@@ -199,14 +203,18 @@ async function runAgentLoop(userMessage: string, broadcast: (event: UIEvent) => 
       break;
     }
     if (calls.length === 0) break;
-    const result = await executeTools(calls, broadcast);
+    const result = await executeTools(calls, broadcast, turnId);
     transcript.push(result || `(ツール ${calls.map((c) => c.name).join(", ")} は結果なし)`);
   }
   return transcript.join("\n\n");
 }
 
 /** Execute planned tools via the Python agent service. Read-only web is auto-confirmed. */
-async function executeTools(calls: ToolCall[], broadcast: (event: UIEvent) => void): Promise<string> {
+async function executeTools(
+  calls: ToolCall[],
+  broadcast: (event: UIEvent) => void,
+  turnId: string | null,
+): Promise<string> {
   const base = config.agentService.baseUrl;
   const blocks: string[] = [];
   for (const call of calls) {
@@ -215,7 +223,7 @@ async function executeTools(calls: ToolCall[], broadcast: (event: UIEvent) => vo
       const res = await fetch(`${base}/tools/${call.name}`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ args: call.args, confirm: true }),
+        body: JSON.stringify({ args: call.args, confirm: true, turn_id: turnId }),
         signal: AbortSignal.timeout(TOOL_EXEC_TIMEOUT_MS),
       });
       if (!res.ok) continue;
@@ -235,6 +243,7 @@ export async function ask(
   userMessage: string,
   broadcast: (event: UIEvent) => void,
   session?: SessionLogger,
+  turnId: string | null = null,
 ): Promise<TurnResult | null> {
   if (STUB_MODE) {
     log.info(`[STUB] responding to: "${userMessage}"`);
@@ -260,7 +269,7 @@ export async function ask(
   // ground the answer in the accumulated results.
   let systemPrompt = systemWithMemory;
   if (TOOL_USE_ENABLED && config.brainBackend === "ollama") {
-    const toolContext = await runAgentLoop(userMessage, broadcast);
+    const toolContext = await runAgentLoop(userMessage, broadcast, turnId);
     if (toolContext) {
       // Tool results often contain paths/URLs/numbers, so relax the short-answer
       // format: allow longer text and symbols (/ . : etc.) to report specifics.

--- a/apps/bridge/src/server.ts
+++ b/apps/bridge/src/server.ts
@@ -39,27 +39,40 @@ async function ensureAgentSession(): Promise<string | null> {
   }
 }
 
-async function logTurnToAgent(result: TurnResult): Promise<string | null> {
+// Open the turn up front (with the user input) so tool calls made during the
+// answer can be logged against a real turn_id. Returns null if the agent is down.
+async function openTurn(userMessage: string): Promise<string | null> {
   const sid = await ensureAgentSession();
   if (!sid) return null;
   try {
     const res = await fetch(`${agentBase}/sessions/${sid}/turns`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        user_input: result.user,
-        assistant_output: result.assistant,
-        model: getCurrentModel(),
-        emotion: result.emotion,
-        motion: result.motion,
-        latency_ms: result.latencyMs,
-      }),
+      body: JSON.stringify({ user_input: userMessage, model: getCurrentModel() }),
     });
     if (!res.ok) return null;
     const data = await res.json() as { id: string };
     return data.id;
   } catch {
-    return null;
+    return null; // agent service not running — skip logging
+  }
+}
+
+// Fill in the assistant side once the answer is ready.
+async function closeTurn(turnId: string, result: TurnResult): Promise<void> {
+  try {
+    await fetch(`${agentBase}/turns/${turnId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        assistant_output: result.assistant,
+        emotion: result.emotion,
+        motion: result.motion,
+        latency_ms: result.latencyMs,
+      }),
+    });
+  } catch {
+    // best-effort
   }
 }
 
@@ -176,9 +189,10 @@ export async function startServer(session?: SessionLogger) {
     broadcast({ type: "status", state: "running", message: "考え中..." });
 
     try {
-      const result = await ask(message, broadcast, session);
+      const turnId = await openTurn(message);
+      const result = await ask(message, broadcast, session, turnId);
       broadcast({ type: "status", state: "idle", message: "Ready" });
-      const turnId = result ? await logTurnToAgent(result) : null;
+      if (turnId && result) await closeTurn(turnId, result);
       return reply.send({ ok: true, turnId });
     } catch (err) {
       log.error("Brain error", err);

--- a/services/agent/src/agent/app.py
+++ b/services/agent/src/agent/app.py
@@ -166,6 +166,16 @@ class LogTurnRequest(BaseModel):
     error: str | None = None
 
 
+class UpdateTurnRequest(BaseModel):
+    assistant_output: str | None = None
+    raw_assistant_output: str | None = None
+    emotion: str | None = None
+    motion: str | None = None
+    latency_ms: int | None = None
+    status: str | None = None
+    error: str | None = None
+
+
 class EndSessionRequest(BaseModel):
     summary: str | None = None
 
@@ -307,6 +317,23 @@ def log_turn(session_id: str, req: LogTurnRequest, logger: LoggerDep) -> TurnLog
 @app.get("/sessions/{session_id}/turns")
 def get_turns(session_id: str, logger: LoggerDep) -> list[TurnLog]:
     return logger.get_turns(session_id)
+
+
+@app.patch("/turns/{turn_id}")
+def update_turn(turn_id: str, req: UpdateTurnRequest, logger: LoggerDep) -> TurnLog:
+    updated = logger.update_turn(
+        turn_id,
+        assistant_output=req.assistant_output,
+        raw_assistant_output=req.raw_assistant_output,
+        emotion=req.emotion,
+        motion=req.motion,
+        latency_ms=req.latency_ms,
+        status=req.status,
+        error=req.error,
+    )
+    if updated is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="turn not found")
+    return updated
 
 
 @app.post("/sessions/{session_id}/end")

--- a/services/agent/src/agent/logger/interaction_logger.py
+++ b/services/agent/src/agent/logger/interaction_logger.py
@@ -35,6 +35,18 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 
 _NEXT_TURN_INDEX = "SELECT COALESCE(MAX(turn_index), -1) + 1 AS next FROM turn_logs WHERE session_id = ?"
 
+_UPDATE_TURN = """
+UPDATE turn_logs SET
+  assistant_output = COALESCE(?, assistant_output),
+  raw_assistant_output = COALESCE(?, raw_assistant_output),
+  emotion = COALESCE(?, emotion),
+  motion = COALESCE(?, motion),
+  latency_ms = COALESCE(?, latency_ms),
+  status = COALESCE(?, status),
+  error = COALESCE(?, error)
+WHERE id = ?
+"""
+
 _INSERT_PROMPT = """
 INSERT INTO prompt_logs
   (id, turn_id, system_prompt, memory_context, recent_context, tool_context,
@@ -282,6 +294,26 @@ class InteractionLogger:
                 ),
             )
         return turn
+
+    def update_turn(
+        self,
+        turn_id: str,
+        *,
+        assistant_output: str | None = None,
+        raw_assistant_output: str | None = None,
+        emotion: str | None = None,
+        motion: str | None = None,
+        latency_ms: int | None = None,
+        status: str | None = None,
+        error: str | None = None,
+    ) -> TurnLog | None:
+        with closing(connect(self._db_path)) as conn, conn:
+            conn.execute(
+                _UPDATE_TURN,
+                (assistant_output, raw_assistant_output, emotion, motion, latency_ms, status, error, turn_id),
+            )
+            row = conn.execute("SELECT * FROM turn_logs WHERE id = ?", (turn_id,)).fetchone()
+        return TurnLog(**dict(row)) if row is not None else None
 
     def end_session(self, session_id: str, summary: str | None = None) -> None:
         with closing(connect(self._db_path)) as conn, conn:

--- a/services/agent/tests/interaction_logger_test.py
+++ b/services/agent/tests/interaction_logger_test.py
@@ -46,6 +46,23 @@ def test_persists_across_logger_instances(tmp_path: Path) -> None:
     assert len(second.get_turns(session.id)) == 1
 
 
+def test_update_turn_fills_in_assistant_side(tmp_path: Path) -> None:
+    db = tmp_path / "app.sqlite"
+    logger = InteractionLogger(db)
+    session = logger.start_session(model="gemma4:31b")
+    # Open the turn with only the user input (as the bridge does before tools run).
+    turn = logger.log_turn(session.id, user_input="今日の天気は")
+    assert turn.assistant_output is None
+
+    updated = logger.update_turn(turn.id, assistant_output="晴れだよ", emotion="happy", latency_ms=1200)
+    assert updated is not None
+    assert updated.assistant_output == "晴れだよ"
+    assert updated.emotion == "happy"
+    assert updated.latency_ms == 1200
+    # user_input is preserved (COALESCE leaves untouched fields).
+    assert updated.user_input == "今日の天気は"
+
+
 def test_sessions_are_listed_independently(tmp_path: Path) -> None:
     logger = InteractionLogger(tmp_path / "app.sqlite")
     a = logger.start_session(model="gemma4:31b")


### PR DESCRIPTION
会話中のツール実行が tool_call_logs に残らず（turn_id 未連携）、ダッシュボード/開発者から「実際に何のツールが・どの引数で・何を返したか」が見えなかった問題を解消。

## 内容
- bridge: ターンを先に開く `openTurn(user_input)`→turn_id、応答後に `closeTurn`(PATCH で assistant 等を更新)。ツール実行時に実在の turn_id を渡せる
- bridge brain.ts: ask→runAgentLoop→executeTools に turnId を伝播、`POST /tools/{name}` の body に turn_id
- agent: `InteractionLogger.update_turn` + `PATCH /turns/{turn_id}` を追加

## 検証
pytest 74 / TS typecheck / bridge 38 passed。ライブで weather 実行が tool_call_logs に記録されることを確認。
→ /dashboard セッション詳細でリトライ含むツール実行を追える。※反映には `pnpm dev:all` 再起動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)