### PR TITLE
fix: filesystem.search が Desktop/Documents/Downloads を優先走査

### DIFF
--- a/services/agent/src/agent/tools/filesystem.py
+++ b/services/agent/src/agent/tools/filesystem.py
@@ -31,6 +31,9 @@ _DENY_SUBSTRINGS = (
 _MAX_READ_BYTES = 1_000_000
 # Directory names pruned during recursive search (noise / heavy / sensitive).
 _SKIP_DIRS = frozenset({"node_modules", "__pycache__", ".venv", "venv", "Library", ".Trash", "dist", "build"})
+# Searched first on a whole-root search so user documents aren't crowded out by
+# large dev/data trees before the result cap is hit.
+_PRIORITY_SUBDIRS = ("Desktop", "Documents", "Downloads")
 _SEARCH_MAX_RESULTS = 50
 _SEARCH_MAX_SCAN = 20_000
 
@@ -77,27 +80,52 @@ class FilesystemTools:
     def search(self, pattern: str, path: str = ".") -> list[dict[str, object]]:
         """Recursively find files matching a glob `pattern` (e.g. '*.pptx') under the root.
 
-        Prunes hidden / heavy dirs, skips sensitive files, and is capped in results
+        On a whole-root search, Desktop/Documents/Downloads are scanned first so a
+        user's files aren't crowded out of the (capped) results by large dev/data
+        trees. Prunes hidden/heavy dirs, skips sensitive files, capped in results
         and files scanned so a large home directory stays responsive.
         """
         base = self._resolve(path)
         if not base.is_dir():
             raise ToolError("not a directory")
         needle = pattern.lower()
+        walk_roots, skip_top = self._search_roots(base)
         results: list[dict[str, object]] = []
+        seen: set[str] = set()
         scanned = 0
-        for dirpath, dirnames, filenames in os.walk(base):
-            dirnames[:] = [d for d in dirnames if not d.startswith(".") and d not in _SKIP_DIRS]
-            for name in filenames:
-                scanned += 1
-                if scanned > _SEARCH_MAX_SCAN:
-                    return results
-                if not fnmatch.fnmatch(name.lower(), needle):
-                    continue
-                full = Path(dirpath) / name
-                if any(token in str(full).lower() for token in _DENY_SUBSTRINGS):
-                    continue
-                results.append({"path": str(full.relative_to(self._root)), "size": full.stat().st_size})
-                if len(results) >= _SEARCH_MAX_RESULTS:
-                    return results
+        for walk_root in walk_roots:
+            for dirpath, dirnames, filenames in os.walk(walk_root):
+                dirnames[:] = [d for d in dirnames if not d.startswith(".") and d not in _SKIP_DIRS]
+                if walk_root == base and dirpath == str(base):
+                    dirnames[:] = [d for d in dirnames if d not in skip_top]  # already walked
+                for name in filenames:
+                    scanned += 1
+                    if scanned > _SEARCH_MAX_SCAN:
+                        return results
+                    if not fnmatch.fnmatch(name.lower(), needle):
+                        continue
+                    full = Path(dirpath) / name
+                    if any(token in str(full).lower() for token in _DENY_SUBSTRINGS):
+                        continue
+                    rel = str(full.relative_to(self._root))
+                    if rel in seen:
+                        continue
+                    seen.add(rel)
+                    results.append({"path": rel, "size": full.stat().st_size})
+                    if len(results) >= _SEARCH_MAX_RESULTS:
+                        return results
         return results
+
+    def _search_roots(self, base: Path) -> tuple[list[Path], set[str]]:
+        """Walk order: priority doc dirs first (only for a whole-root search), then base."""
+        if base != self._root:
+            return [base], set()
+        roots: list[Path] = []
+        skip_top: set[str] = set()
+        for sub in _PRIORITY_SUBDIRS:
+            candidate = base / sub
+            if candidate.is_dir():
+                roots.append(candidate)
+                skip_top.add(sub)
+        roots.append(base)
+        return roots, skip_top

--- a/services/agent/tests/filesystem_search_test.py
+++ b/services/agent/tests/filesystem_search_test.py
@@ -41,3 +41,17 @@ def test_search_name_substring(tmp_path: Path) -> None:
 def test_search_no_match(tmp_path: Path) -> None:
     fs = FilesystemTools(_workspace(tmp_path))
     assert fs.search("*.xlsx") == []
+
+
+def test_search_prioritizes_document_dirs_over_noise(tmp_path: Path) -> None:
+    # A user's file in Documents must not be crowded out of the capped results by
+    # a large dev/data tree (regression: 622 pptx in dev/ hid Documents/Downloads).
+    (tmp_path / "Documents").mkdir()
+    (tmp_path / "Documents" / "自己紹介資料.pptx").write_text("x", encoding="utf-8")
+    noisy = tmp_path / "dev" / "data"
+    noisy.mkdir(parents=True)
+    for i in range(60):  # exceeds the result cap
+        (noisy / f"export_{i}.pptx").write_text("x", encoding="utf-8")
+
+    paths = {h["path"] for h in FilesystemTools(tmp_path).search("*.pptx")}
+    assert "Documents/自己紹介資料.pptx" in paths


### PR DESCRIPTION
`~/Documents/データテクノロジー二部キックオフ_石垣.pptx` が見つからない原因を特定: `dev/` 配下に 622 件の pptx(slack_exports)があり、50件/2万走査の上限に先に到達して Documents/Downloads まで辿り着けていなかった（`*石垣*` すら 0 件）。

## 内容
- `search`: whole-root 検索時は Desktop/Documents/Downloads を先に走査→その後 base（seen で重複除外、上限/除外/隠しdir プルーニングは維持）
- `_search_roots` ヘルパに走査順を分離
- test: Documents のファイルが大量の dev/data に埋もれず結果に入ることを固定

## 検証（ollama 不要・純Python）
- `*石垣*` → `Documents/データテクノロジー二部キックオフ_石垣.pptx` 先頭
- `*自己紹介*` → `Downloads/【Creative Legal GYM】自己紹介_石垣龍馬.pptx`
- pytest 75 passed / ruff・format green

🤖 Generated with [Claude Code](https://claude.com/claude-code)